### PR TITLE
Add pdf thumb/link

### DIFF
--- a/assets/sass/pages/_unsere-geschichte.scss
+++ b/assets/sass/pages/_unsere-geschichte.scss
@@ -10,4 +10,21 @@
 	p { margin-bottom: $margin-s; }
 
 	h3 { margin-bottom: 2rem; }
+
+	&__pdf {
+
+		&-container {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+		}
+
+		&-link {
+			border: 2px solid transparent;
+
+			&:hover {
+				border: 2px solid $chinder-orange;
+			}
+		}
+	}
 }

--- a/layouts/_default/unsere-geschichte.html
+++ b/layouts/_default/unsere-geschichte.html
@@ -5,5 +5,11 @@
 			<img src="https://res.cloudinary.com/chinderzytig/image/upload/c_scale,q_auto:good,w_800/v1597073206/logos/Chinderzytig_Jugenzytig_mmd9rl.png" alt="Chinderzytig/Jungendzytig logo" class="geschichte__img">
 		</div>
 		{{.Content}}
+		<div class="geschichte__pdf-container">
+			<a href="https://res.cloudinary.com/chinderzytig/image/upload/v1597063305/chinderzytig_idee_ooy6my.pdf" target="_blank" class="geschichte__pdf-link">
+				<img src="https://res.cloudinary.com/chinderzytig/image/upload/c_scale,h_300,q_auto:best/v1597063305/chinderzytig_idee_ooy6my.png" alt="">
+			</a>
+			<div class="geschichte__pdf-title">projektidee_chinderzytig.pdf</div>
+		</div>
 	</section>
 {{end}}


### PR DESCRIPTION
Now that Cloudinary lifted the PDF restriction on our account, I was able to add the PDF associated to the Unsere Geschichte page:
<img width="1225" alt="CleanShot 2020-08-11 at 15 50 24@2x" src="https://user-images.githubusercontent.com/16960228/89905380-a3c1e180-dbd9-11ea-9a7c-8a3de2879d73.png">
