### PR TITLE
Create Unser Beirat page

### DIFF
--- a/assets/sass/base/_typography.scss
+++ b/assets/sass/base/_typography.scss
@@ -98,6 +98,8 @@ body {
 /* ----- PROFILE ------ */
 .profile {
 
+	&__content { text-align: center; }
+
 	&__name,
 	&__title { font-family: $font-patrick, $font-fallback; }
 
@@ -110,8 +112,6 @@ body {
 		font-size: $font-default;
 		color: $chinder-verdigris;
 	}
-
-	&__background { text-align: justify; }
 }
 
 

--- a/assets/sass/components/_profile.scss
+++ b/assets/sass/components/_profile.scss
@@ -1,11 +1,21 @@
 .profile {
-	height: 18rem;
-	width: 50rem;
+	height: 40rem;
+	width: 30rem;
 	background-color: $chinder-cultured;
+	border: 1px solid $chinder-platinum;
 	display: flex;
+	flex-direction: column;
+	align-items: center;
+	padding: 2rem;
 	margin-top: 3rem;
 
-	&__content { padding: 1.5rem; }
+	&__img {
+		width: 18rem;
+		height: 18rem;
+		border-radius: 50%;
+	}
+
+	&__content { margin-top: 1rem; }
 
 	&__background { margin-top: 1rem; }
 

--- a/assets/sass/components/_profile.scss
+++ b/assets/sass/components/_profile.scss
@@ -1,6 +1,5 @@
 .profile {
-	height: 40rem;
-	width: 30rem;
+
 	background-color: $chinder-cultured;
 	border: 1px solid $chinder-platinum;
 	display: flex;
@@ -8,6 +7,10 @@
 	align-items: center;
 	padding: 2rem;
 	margin-top: 3rem;
+
+	&--team { width: 30rem; }
+
+	&--board { width: 45rem; }
 
 	&__img {
 		width: 18rem;

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -20,5 +20,6 @@
 @import "pages/fokus_der_woche";
 @import "pages/index";
 @import "pages/über-uns";
+@import "pages/unser-beirat";
 @import "pages/unsere-geschichte";
 @import "pages/verein";

--- a/assets/sass/pages/_unser-beirat.scss
+++ b/assets/sass/pages/_unser-beirat.scss
@@ -1,0 +1,3 @@
+.board {
+	@include container-main;
+}

--- a/assets/sass/pages/_über-uns.scss
+++ b/assets/sass/pages/_über-uns.scss
@@ -6,10 +6,11 @@
 	&__others {
 		margin-top: -3rem;
 		display: flex;
+		justify-content: space-around;
 		flex-wrap: wrap;
 
 		&-group {
-			width: 50%;
+			width: 40%;
 			margin-top: 3rem;
 		}
 

--- a/content/unser-beirat.md
+++ b/content/unser-beirat.md
@@ -1,0 +1,4 @@
+---
+title: "Unser Beirat"
+layout: unser-beirat
+---

--- a/data/pages/beirat.yaml
+++ b/data/pages/beirat.yaml
@@ -37,7 +37,7 @@ board:
         auch die grossen Themen. Um diese altersgerecht vermitteln und
         diskutieren zu können, leistet die Chinder- und Jugendzytig einen
         wichtigen Beitrag."
-- img: "https://res.cloudinary.com/chinderzytig/image/upload/c_scale,w_180,q_auto:good/people/felix_gq4zwu.jpg"
+- img: "https://res.cloudinary.com/chinderzytig/image/upload/c_scale,w_180,q_auto:good/people/felix_bme5lr.jpg"
   desc: Felix E. Müller
   info:
     - name: Felix E. Müller

--- a/data/pages/beirat.yaml
+++ b/data/pages/beirat.yaml
@@ -1,0 +1,57 @@
+board:
+- img: "https://res.cloudinary.com/chinderzytig/image/upload/c_scale,w_180,q_auto:good/people/matthias_efpryu.jpg"
+  desc: Matthias Aebischer
+  info:
+    - name: Matthias Aebischer
+      title: Nationalrat, Dozent, Journalist
+      quote: |
+        "Informationen speziell für Kinder und Jugendliche zubereitet ist etwas
+        vom Wichtigsten. Denn die gut informierte Bevölkerung bildet die Basis
+        einer stabilen Demokratie."
+- img: "https://res.cloudinary.com/chinderzytig/image/upload/c_scale,w_180,q_auto:good/people/rosmarie_uc6gje.jpg"
+  desc: Rosmarie Bernasconi
+  info:
+    - name: Rosmarie Bernasconi
+      title: BuchhändlerinVerlag Einfach Lesen, Buchautorin
+      quote: |
+        "Die Chinderzytig vermittelt Inhalte, die man nicht überall lesen kann
+        und ich finde es wichtig, dass Kinder und Jugendliche sich mit dem Wort
+        und den Themen der Gesellschaft auseinandersetzen. Ich mag die
+        Chinderzytig auch, weil es eine Teamarbeit ist!"
+- img: "https://res.cloudinary.com/chinderzytig/image/upload/c_scale,w_180,q_auto:good/people/katharina_xcwoed.jpg"
+  desc: Katharina Kalcsics, Prof. Dr.
+  info:
+    - name: Katharina Kalcsics, Prof. Dr.
+      title: Leiterin Fachdidaktikzentrum NMG + NE, PHBern
+      quote: |
+        "Kinder haben ein Recht auf Information über aktuelle, gesellschaftliche
+        Themen, sie haben ein Recht selbst lesen zu dürfen, deshalb braucht es
+        Angebote wie die Chinderzytig."
+- img: "https://res.cloudinary.com/chinderzytig/image/upload/c_scale,w_180,q_auto:good/people/dominik_tiv6pg.jpg"
+  desc: Dominik Mösching
+  info:
+    - name: Dominik Mösching
+      title: Organisationsentwickler, Sozialwissenschaftler Stadt Bern
+      quote: |
+        "Menschen sind von Natur aus neugierig. Von klein auf interessieren uns
+        auch die grossen Themen. Um diese altersgerecht vermitteln und
+        diskutieren zu können, leistet die Chinder- und Jugendzytig einen
+        wichtigen Beitrag."
+- img: "https://res.cloudinary.com/chinderzytig/image/upload/c_scale,w_180,q_auto:good/people/felix_gq4zwu.jpg"
+  desc: Felix E. Müller
+  info:
+    - name: Felix E. Müller
+      title: Ehemaliger Chefredaktor NZZ am Sonntag
+      quote: |
+        "Bei diesem systematischen und wichtigen Projekt bin ich gerne dabei.
+        Ich gratuliere zu diesem Engagement und unterstütze die Chinderzytig
+        gerne."
+- img: "https://res.cloudinary.com/chinderzytig/image/upload/c_scale,w_180,q_auto:good/people/jolan_so99rr.jpg"
+  desc: Jolan Ziörjen
+  info:
+    - name: Jolan Ziörjen
+      title: Schüler, Leser, Inspirationsquelle
+      quote: |
+        "Für Kinder in meinem Alter, die gerne wissen wollen, was auf der Welt
+        passiert, und gleichzeitig Zeit am Bildschirm verbringen wollen, ist die
+        Chinderzytig ein perfekter Mix."

--- a/data/pages/verein.yaml
+++ b/data/pages/verein.yaml
@@ -22,7 +22,7 @@ btns:
 - url: "/über-uns"
   label:
     - text: Über Uns
-- url: "#"
+- url: "/unser-beirat"
   label:
     - text: Unser Beirat
 - url: "#"

--- a/data/pages/über.yaml
+++ b/data/pages/über.yaml
@@ -4,37 +4,37 @@ team:
   info:
     - name: Yvonne Bischof
       title: Verantwortung Ressort Bildung, Co-Präsidentin
-      sme: Lehrperson Zyklus 2
+      focus: Lehrperson Zyklus 2
 - img: "https://res.cloudinary.com/chinderzytig/image/upload/c_scale,e_grayscale,w_180,q_auto:good/people/seraina_oo1jvl.png"
   desc: Seraina Branschi
   info:
     - name: Seraina Branschi
       title: Verantwortung Redaktion und Website
-      sme: Mitarbeiterin Marketing & Kommunikation, Swiss Economic Forum & NZZ Konferenzen
+      focus: Mitarbeiterin Marketing & Kommunikation, Swiss Economic Forum & NZZ Konferenzen
 - img: "https://res.cloudinary.com/chinderzytig/image/upload/c_scale,e_grayscale,w_180,q_auto:good/people/melanie_eju55k.jpg"
   desc: Melanie Cabalerio
   info:
     - name: Melanie Cabalerio
       title: Verantwortung Ressort Bildung / Marketing
-      sme: Lehrperson Zyklus 2
+      focus: Lehrperson Zyklus 2
 - img: "https://res.cloudinary.com/chinderzytig/image/upload/c_scale,e_grayscale,w_180,q_auto:good/people/simone_ninxtj.jpg"
   desc: Simone Gefeller
   info:
     - name: Simone Gefeller
       title: Verantwortung Datenbankbewirtschaftung / Ressort Bildung
-      sme: Lehrperson Zyklus 1
+      focus: Lehrperson Zyklus 1
 - img: "https://res.cloudinary.com/chinderzytig/image/upload/c_scale,e_grayscale,w_180,q_auto:good/people/isabel_u1reb4.png"
   desc: Isabel Niklaus
   info:
     - name: Isabel Niklaus
       title: Verantwortung Marketing / Kommunikation / Sales
-      sme: Projektleiterin, Swiss Economic Forum & NZZ Konferenzen
+      focus: Projektleiterin, Swiss Economic Forum & NZZ Konferenzen
 - img: "https://res.cloudinary.com/chinderzytig/image/upload/c_scale,e_grayscale,w_180,q_auto:good/people/lars_w1kacn.jpg"
   desc: Lars Ziörjen
   info:
     - name: Lars Ziörjen
       title: Gesamtverantwortung, Co-Präsident
-      sme: Lehrperson Zyklus 3, Schulleiter, Theater- und Kinderbuchautor
+      focus: Lehrperson Zyklus 3, Schulleiter, Theater- und Kinderbuchautor
 
 others:
 - heading: Finanzen

--- a/layouts/_default/unser-beirat.html
+++ b/layouts/_default/unser-beirat.html
@@ -1,0 +1,3 @@
+{{define "main"}}
+
+{{end}}

--- a/layouts/_default/unser-beirat.html
+++ b/layouts/_default/unser-beirat.html
@@ -1,3 +1,19 @@
 {{define "main"}}
-
+	<section class="board">
+		<h2 class="heading heading__secondary">Unser Beirat</h2>
+		<div class="profile__container">
+			{{ range .Site.Data.pages.beirat.board }}
+				<div class="profile profile--board">
+					<img src="{{ .img }}" alt="{{ .desc }}" class="profile__img">
+					<div class="profile__content">
+						{{ range .info }}
+							<h3 class="profile__name">{{ .name }}</h3>
+							<div class="profile__title">{{ .title }}</div>
+							<div class="profile__background">{{ .quote }}</div>
+						{{ end }}
+					</div>
+				</div>
+			{{ end }}
+		</div>
+	</section>
 {{end}}

--- a/layouts/_default/über-uns.html
+++ b/layouts/_default/über-uns.html
@@ -3,13 +3,13 @@
 		<h2 class="heading heading__secondary">Über Uns</h2>
 		<div class="profile__container">
 			{{ range .Site.Data.pages.über.team }}
-				<div class="profile">
+				<div class="profile profile--team">
 					<img src="{{ .img }}" alt="{{ .desc }}" class="profile__img">
 					<div class="profile__content">
 						{{ range .info }}
 							<h3 class="profile__name">{{ .name }}</h3>
 							<div class="profile__title">{{ .title }}</div>
-							<div class="profile__background">{{ .sme }}</div>
+							<div class="profile__focus">{{ .focus }}</div>
 						{{ end }}
 					</div>
 				</div>


### PR DESCRIPTION
As per the original design, I revert back to profiles with circular images on the about us page, and created the board member page:

**About Us**
![CleanShot 2020-08-26 at 16 08 30@2x](https://user-images.githubusercontent.com/16960228/91314081-b0cbfc80-e7a5-11ea-9793-363a68a68603.png)

**Our Board**
![CleanShot 2020-08-26 at 16 04 34@2x](https://user-images.githubusercontent.com/16960228/91314131-c0e3dc00-e7a5-11ea-842b-9159a5498119.png)
