### PR TITLE
Unsere Quellen page

### DIFF
--- a/assets/sass/base/_typography.scss
+++ b/assets/sass/base/_typography.scss
@@ -297,15 +297,16 @@ body {
 	}
 }
 
-/* ----- DER VEREIN ------ */
-.verein {
+/* ----- ÜBER UNS ------ */
+.about {
 
-	&__history-quote {
-		font-family: $font-patrick, $font-fallback;
-		font-size: 5rem;
-		word-spacing: 1rem;
-		letter-spacing: .5rem;
-		text-decoration: $chinder-orange underline;
+	&__others {
+
+		&-heading {
+			font-family: $font-patrick, $font-fallback;
+			font-size: $font-bigger;
+			color: $chinder-orange;
+		}
 	}
 }
 
@@ -329,15 +330,32 @@ body {
 	}
 }
 
-/* ----- ÜBER UNS ------ */
-.about {
+/* ----- UNSERE QUELLEN ------ */
 
-	&__others {
+.quellen {
 
-		&-heading {
-			font-family: $font-patrick, $font-fallback;
-			font-size: $font-bigger;
-			color: $chinder-orange;
+	&__media {
+
+		&-text { font-weight: 100; }
+	}
+
+	&__other {
+
+		&-text {
+			font-weight: 100;
+			text-align: justify;
 		}
+	}
+}
+
+/* ----- DER VEREIN ------ */
+.verein {
+
+	&__history-quote {
+		font-family: $font-patrick, $font-fallback;
+		font-size: 5rem;
+		word-spacing: 1rem;
+		letter-spacing: .5rem;
+		text-decoration: $chinder-orange underline;
 	}
 }

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -22,4 +22,5 @@
 @import "pages/über-uns";
 @import "pages/unser-beirat";
 @import "pages/unsere-geschichte";
+@import "pages/unsere-quellen";
 @import "pages/verein";

--- a/assets/sass/pages/_unsere-quellen.scss
+++ b/assets/sass/pages/_unsere-quellen.scss
@@ -1,0 +1,6 @@
+.quellen {
+
+	&__intro {
+		@include container-main;
+	}
+}

--- a/assets/sass/pages/_unsere-quellen.scss
+++ b/assets/sass/pages/_unsere-quellen.scss
@@ -1,11 +1,12 @@
 .quellen {
 
-	&__intro,
-	&__logos-container { @include container-main; }
+	&__media-intro,
+	&__logos-container,
+	&__other { @include container-main; }
 
-	&__intro {
+	&__media {
 
-		&-content { margin-bottom: 3rem; }
+		&-text { margin-bottom: 3rem; }
 	}
 
 	&__logos {
@@ -16,6 +17,22 @@
 			flex-wrap: wrap;
 			justify-content: space-around;
 			align-items: center;
+		}
+
+		&-logo { padding: 2rem; }
+	}
+
+	&__other {
+		border: 1px solid $color-black;
+		padding: 2rem;
+		display: flex;
+
+		&-logo { padding: 2rem; }
+
+		&-text {
+			border-left: 1px solid $chinder-platinum;
+			border-right: 1px solid $chinder-platinum;
+			padding: 0 2rem;
 		}
 	}
 }

--- a/assets/sass/pages/_unsere-quellen.scss
+++ b/assets/sass/pages/_unsere-quellen.scss
@@ -1,6 +1,21 @@
 .quellen {
 
+	&__intro,
+	&__logos-container { @include container-main; }
+
 	&__intro {
-		@include container-main;
+
+		&-content { margin-bottom: 3rem; }
+	}
+
+	&__logos {
+		@include cta-color($chinder-cultured);
+
+		&-container {
+			display: flex;
+			flex-wrap: wrap;
+			justify-content: space-around;
+			align-items: center;
+		}
 	}
 }

--- a/content/unsere-quellen.md
+++ b/content/unsere-quellen.md
@@ -1,0 +1,4 @@
+---
+title: "Unsere Quellen"
+layout: unsere-quellen
+---

--- a/data/pages/quellen.yaml
+++ b/data/pages/quellen.yaml
@@ -1,0 +1,37 @@
+media:
+- website: "https://www.derbund.ch/"
+  logo:
+    - img: "https://res.cloudinary.com/chinderzytig/image/upload/c_scale,h_60,q_auto:good/logos/derbund_tjlcwf.png"
+      desc: Der Bund logo
+- website: "https://www.nzz.ch/"
+  logo:
+    - img: "https://res.cloudinary.com/chinderzytig/image/upload/c_scale,h_60,q_auto:good/logos/nzz_jfrc3m.png"
+      desc: NZZ logo
+- website: "https://nzzas.nzz.ch/"
+  logo:
+    - img: "https://res.cloudinary.com/chinderzytig/image/upload/c_scale,h_60,q_auto:good/logos/nzz_am_zontag_ieeao5.png"
+      desc: NZZ am Sonntag logo
+- website: "https://www.srf.ch/news"
+  logo:
+    - img: "https://res.cloudinary.com/chinderzytig/image/upload/c_scale,h_60,q_auto:good/logos/srf_j7oz5s.png"
+      desc: SRF logo
+- website: "https://www.watson.ch/"
+  logo:
+    - img: "https://res.cloudinary.com/chinderzytig/image/upload/c_scale,h_60,q_auto:good/logos/watson_hy9n8j.png"
+      desc: Watson logo
+- website: "https://edition.cnn.com/"
+  logo:
+    - img: "https://res.cloudinary.com/chinderzytig/image/upload/c_scale,h_60,q_auto:good/logos/cnn_hxajyz.png"
+      desc: CNN logo
+- website: "https://www.zeit.de/index"
+  logo:
+    - img: "https://res.cloudinary.com/chinderzytig/image/upload/c_scale,h_60,q_auto:good/logos/die_zeit_vlnmrj.png"
+      desc: Die Zeit logo
+- website: "https://de.wikipedia.org/"
+  logo:
+    - img: "https://res.cloudinary.com/chinderzytig/image/upload/c_scale,h_60,q_auto:good/logos/wiki_wv2jcn.png"
+      desc: Wikipedia logo
+- website: "https://www.20min.ch/"
+  logo:
+    - img: "https://res.cloudinary.com/chinderzytig/image/upload/c_scale,h_60,q_auto:good/logos/20minuten_ep2xwv.png"
+      desc: 20 Minuten logo

--- a/data/pages/verein.yaml
+++ b/data/pages/verein.yaml
@@ -25,7 +25,7 @@ btns:
 - url: "/unser-beirat"
   label:
     - text: Unser Beirat
-- url: "#"
+- url: "/unsere-quellen"
   label:
     - text: Unsere Quellen
 - url: "#"

--- a/layouts/_default/unsere-quellen.html
+++ b/layouts/_default/unsere-quellen.html
@@ -2,6 +2,21 @@
 	<section class="quellen">
 		<div class="quellen__intro">
 			<h2 class="heading heading__secondary">Unsere Quellen</h2>
+			<p class="quellen__intro-content">
+				Wir beziehen unsere Informationen primär aus dem Internet und aus
+				Printmedien. 99% der Informationen stammen von:
+			</p>
+		</div>
+		<div class="quellen__logos">
+			<div class="quellen__logos-container">
+				{{ range .Site.Data.pages.quellen.media }}
+					<a href="{{ .website }}" target="_blank" class="verein__thanks-link">
+					{{ range .logo }}
+						<img src="{{ .img }}" alt="{{ .desc }}" class="verein__thanks-logo">
+					{{ end }}
+					</a>
+				{{ end }}
+			</div>
 		</div>
 	</section>
 {{end}}

--- a/layouts/_default/unsere-quellen.html
+++ b/layouts/_default/unsere-quellen.html
@@ -1,0 +1,7 @@
+{{define "main"}}
+	<section class="quellen">
+		<div class="quellen__intro">
+			<h2 class="heading heading__secondary">Unsere Quellen</h2>
+		</div>
+	</section>
+{{end}}

--- a/layouts/_default/unsere-quellen.html
+++ b/layouts/_default/unsere-quellen.html
@@ -1,8 +1,8 @@
 {{define "main"}}
-	<section class="quellen">
-		<div class="quellen__intro">
+	<section class="quellen__media">
+		<div class="quellen__media-intro">
 			<h2 class="heading heading__secondary">Unsere Quellen</h2>
-			<p class="quellen__intro-content">
+			<p class="quellen__media-text">
 				Wir beziehen unsere Informationen primär aus dem Internet und aus
 				Printmedien. 99% der Informationen stammen von:
 			</p>
@@ -10,13 +10,23 @@
 		<div class="quellen__logos">
 			<div class="quellen__logos-container">
 				{{ range .Site.Data.pages.quellen.media }}
-					<a href="{{ .website }}" target="_blank" class="verein__thanks-link">
+					<a href="{{ .website }}" target="_blank" class="quellen__logos-link">
 					{{ range .logo }}
-						<img src="{{ .img }}" alt="{{ .desc }}" class="verein__thanks-logo">
+						<img src="{{ .img }}" alt="{{ .desc }}" class="quellen__logos-logo">
 					{{ end }}
 					</a>
 				{{ end }}
 			</div>
 		</div>
+	</section>
+	<section class="quellen__other">
+		<img src="https://res.cloudinary.com/chinderzytig/image/upload/c_scale,h_80,q_auto:good/logos/swiss_gov_julv3s.png" alt="Swiss Government logo" class="quellen__other-logo">
+		<div class="quellen__other-divider"></div>
+		<p class="quellen__other-text">
+			Als zusätzliche Quellen dienen Der Bund kurz erklärt (Publikation der
+			Eidgenossenschaft) und Lehrmittel der Schulen des Kantons Bern wie zum
+			Beispiel Durch Geschichte zur Gegenwart, Zeitreise 7-9, und Durchblick.
+		</p>
+		<img src="https://res.cloudinary.com/chinderzytig/image/upload/c_scale,h_80,q_auto:good/logos/kanton_bern_bgvmlz.jpg" alt="Canton Bern logo" class="quellen__other-logo">
 	</section>
 {{end}}


### PR DESCRIPTION
Created Unsere Quellen page without reference to Ecosia image use as, upon further investigation, is not true. This should be discussed further if this element is to be re-introduced, but I feel that the requirement to cite all images as part of the new design, should suffice without the need for such a bold statement.

![CleanShot 2020-08-27 at 12 02 09@2x](https://user-images.githubusercontent.com/16960228/91426741-70738980-e84c-11ea-9dc8-42bd82f4cf5c.png)
 