### PR TITLE
Add breadcrumb component

### DIFF
--- a/assets/sass/base/_typography.scss
+++ b/assets/sass/base/_typography.scss
@@ -73,6 +73,8 @@ body {
 		text-decoration: none;
 		color: $color-black;
 	}
+
+	&__active { @extend .breadcrumb__link; }
 }
 
 /* ----- BUTTONS ------ */

--- a/assets/sass/base/_typography.scss
+++ b/assets/sass/base/_typography.scss
@@ -65,6 +65,16 @@ body {
 	}
 }
 
+/* ----- BREADCRUMB ------ */
+.breadcrumb {
+
+	&__link:link,
+	&__link:visited {
+		text-decoration: none;
+		color: $color-black;
+	}
+}
+
 /* ----- BUTTONS ------ */
 .btn {
 	font-family: $font-patrick, $font-fallback;

--- a/assets/sass/base/_typography.scss
+++ b/assets/sass/base/_typography.scss
@@ -70,6 +70,7 @@ body {
 
 	&__link:link,
 	&__link:visited {
+		font-weight: 500;
 		text-decoration: none;
 		color: $color-black;
 	}

--- a/assets/sass/components/_breadcrumb.scss
+++ b/assets/sass/components/_breadcrumb.scss
@@ -24,5 +24,7 @@
 	}
 
 	&__link:hover,
-	&__link:active { border-bottom: 2px solid $chinder-verdigris; }
+	&__link:active { border-bottom: 2px solid $chinder-orange; }
+
+	&__active { border-bottom: 2px solid $chinder-verdigris; }
 }

--- a/assets/sass/components/_breadcrumb.scss
+++ b/assets/sass/components/_breadcrumb.scss
@@ -1,0 +1,28 @@
+.breadcrumb	{
+
+	&__container { @include container-main; }
+
+	&__group-container {
+		display: flex;
+		justify-content: center;
+	}
+
+	&__group {
+		width: 65%;
+		list-style: none;
+		padding-left: 0;
+		border: 1px solid $color-black;
+		padding: 1rem;
+		display: flex;
+		justify-content: center;
+	}
+
+	&__item {
+		padding: 1rem;
+
+		&:not(:last-child) { border-right: 1px solid $chinder-cultured; }
+	}
+
+	&__link:hover,
+	&__link:active { border-bottom: 2px solid $chinder-verdigris; }
+}

--- a/assets/sass/components/_breadcrumb.scss
+++ b/assets/sass/components/_breadcrumb.scss
@@ -8,19 +8,14 @@
 	}
 
 	&__group {
-		width: 65%;
 		list-style: none;
-		padding-left: 0;
-		border: 1px solid $color-black;
-		padding: 1rem;
 		display: flex;
-		justify-content: center;
 	}
 
 	&__item {
 		padding: 1rem;
 
-		&:not(:last-child) { border-right: 1px solid $chinder-cultured; }
+		&:not(:last-child) { border-right: 1px solid $chinder-platinum; }
 	}
 
 	&__link:hover,

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -4,6 +4,7 @@
 @import "base/base";
 @import "base/typography";
 
+@import "components/breadcrumb";
 @import "components/btn";
 @import "components/card";
 @import "components/fdw_svg";

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -7,5 +7,20 @@
 			{{- block "main" . }}{{- end }}
 		</main>
 		{{- partial "footer.html" . -}}
+		<script>
+			(function () {
+				var bread = document.getElementById('bread');
+				anchor = bread.getElementsByTagName('a');
+				current = window.location.href;
+				console.log(anchor[0].href);
+				console.log(current);
+
+				for (var i = 0; i < anchor.length; i++) {
+					if (anchor[i].href == current) {
+						anchor[i].className = 'breadcrumb__active';
+					}
+				}
+			})();
+		</script>
 	</body>
 </html>

--- a/layouts/_default/unser-beirat.html
+++ b/layouts/_default/unser-beirat.html
@@ -1,4 +1,7 @@
 {{define "main"}}
+	<section class="breadcrumb__container">
+		{{- partial "breadcrumb.html" . -}}
+	</section>
 	<section class="board">
 		<h2 class="heading heading__secondary">Unser Beirat</h2>
 		<div class="profile__container">

--- a/layouts/_default/unsere-geschichte.html
+++ b/layouts/_default/unsere-geschichte.html
@@ -1,4 +1,7 @@
 {{define "main"}}
+	<section class="breadcrumb__container">
+		{{- partial "breadcrumb.html" . -}}
+	</section>
 	<section class="geschichte">
 		<h2 class="heading heading__secondary">Unsere Geschichte</h2>
 		<div class="geschichte__logo-container">

--- a/layouts/_default/unsere-quellen.html
+++ b/layouts/_default/unsere-quellen.html
@@ -1,4 +1,7 @@
 {{define "main"}}
+	<section class="breadcrumb__container">
+		{{- partial "breadcrumb.html" . -}}
+	</section>
 	<section class="quellen__media">
 		<div class="quellen__media-intro">
 			<h2 class="heading heading__secondary">Unsere Quellen</h2>

--- a/layouts/_default/über-uns.html
+++ b/layouts/_default/über-uns.html
@@ -1,4 +1,7 @@
 {{define "main"}}
+	<section class="breadcrumb__container">
+		{{- partial "breadcrumb.html" . -}}
+	</section>
 	<section class="about__team">
 		<h2 class="heading heading__secondary">Über Uns</h2>
 		<div class="profile__container">

--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -2,9 +2,9 @@
 	<div class="breadcrumb__group-container">
 		<ul class="breadcrumb__group" id="bread">
 			<li class="breadcrumb__item"><a href="/unsere-geschichte/" class="breadcrumb__link">Unsere Geschichte</a></li>
-			<li class="breadcrumb__item"><a href="/über-uns" class="breadcrumb__link">Über Uns</a></li>
-			<li class="breadcrumb__item"><a href="/unser-beirat" class="breadcrumb__link">Unser Beirat</a></li>
-			<li class="breadcrumb__item"><a href="/unsere-quellen" class="breadcrumb__link">Unsere Quellen</a></li>
+			<li class="breadcrumb__item"><a href="/über-uns/" class="breadcrumb__link">Über Uns</a></li>
+			<li class="breadcrumb__item"><a href="/unser-beirat/" class="breadcrumb__link">Unser Beirat</a></li>
+			<li class="breadcrumb__item"><a href="/unsere-quellen/" class="breadcrumb__link">Unsere Quellen</a></li>
 			<li class="breadcrumb__item"><a href="#" class="breadcrumb__link">Kontaktiere Uns</a></li>
 		</ul>
 	</div>

--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -1,11 +1,11 @@
 <div class="breadcrumb">
 	<div class="breadcrumb__group-container">
-		<ul class="breadcrumb__group">
-			<li class="breadcrumb__item"><a href="/unsere-geschichte" class="breadcrumb__link">Unsere Geschichte</a></li>
+		<ul class="breadcrumb__group" id="bread">
+			<li class="breadcrumb__item"><a href="/unsere-geschichte/" class="breadcrumb__link">Unsere Geschichte</a></li>
 			<li class="breadcrumb__item"><a href="/über-uns" class="breadcrumb__link">Über Uns</a></li>
 			<li class="breadcrumb__item"><a href="/unser-beirat" class="breadcrumb__link">Unser Beirat</a></li>
 			<li class="breadcrumb__item"><a href="/unsere-quellen" class="breadcrumb__link">Unsere Quellen</a></li>
-			<li class="breadcrumb__item"><a href="" class="breadcrumb__link">Kontaktiere Uns</a></li>
+			<li class="breadcrumb__item"><a href="#" class="breadcrumb__link">Kontaktiere Uns</a></li>
 		</ul>
 	</div>
 </div>

--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -1,0 +1,11 @@
+<div class="breadcrumb">
+	<div class="breadcrumb__group-container">
+		<ul class="breadcrumb__group">
+			<li class="breadcrumb__item"><a href="/unsere-geschichte" class="breadcrumb__link">Unsere Geschichte</a></li>
+			<li class="breadcrumb__item"><a href="/über-uns" class="breadcrumb__link">Über Uns</a></li>
+			<li class="breadcrumb__item"><a href="/unser-beirat" class="breadcrumb__link">Unser Beirat</a></li>
+			<li class="breadcrumb__item"><a href="/unsere-quellen" class="breadcrumb__link">Unsere Quellen</a></li>
+			<li class="breadcrumb__item"><a href="" class="breadcrumb__link">Kontaktiere Uns</a></li>
+		</ul>
+	</div>
+</div>


### PR DESCRIPTION
Created breadcrumb component for pages that specifically branch off the Der Verein page, making for easy navigation between said pages without the need to traverse back to `/der-verein`.

The breadcrumb will also highlight the respective page when active:

![CleanShot 2020-08-31 at 16 32 18](https://user-images.githubusercontent.com/16960228/91731888-f9652a80-eb96-11ea-821a-838c0d556c29.gif)
