### PR TITLE
Add Kontakt social icons

### DIFF
--- a/assets/sass/base/_typography.scss
+++ b/assets/sass/base/_typography.scss
@@ -322,6 +322,8 @@ body {
 		font-family: inherit;
 		font-size: inherit;
 	}
+
+	&__datenschutz { color: $chinder-orange; }
 }
 
 /* ----- ÜBER UNS ------ */

--- a/assets/sass/components/_social_svgs.scss
+++ b/assets/sass/components/_social_svgs.scss
@@ -1,5 +1,6 @@
 .social-icon {
 	fill: $chinder-platinum;
+	text-decoration: none;
 
 	&:active,
 		&:hover { fill: $chinder-verdigris; }

--- a/assets/sass/pages/_kontakt.scss
+++ b/assets/sass/pages/_kontakt.scss
@@ -9,6 +9,8 @@
 		background-color: $chinder-cultured;
 	}
 
+	&__social { margin-left: 4rem; }
+
 	&__form {
 		padding: 3rem;
 		display: flex;

--- a/layouts/_default/kontakt.html
+++ b/layouts/_default/kontakt.html
@@ -42,7 +42,7 @@
 					<label for="datenschutz">
 						Ich bin einverstanden, dass meine Personendaten im Kontext dieses
 						Formulars verarbeitet werden. Mehr Informationen finden Sie unter
-						chinderzytig.ch/datenschutz.
+						<a href="#" class="kontakt__datenschutz">chinderzytig.ch/datenschutz</a>.
 					</label>
 				</div>
 				<div class="kontakt__hidden">

--- a/layouts/_default/kontakt.html
+++ b/layouts/_default/kontakt.html
@@ -1,6 +1,9 @@
 {{define "main"}}
 	<section class="kontakt">
-		<h2 class="heading heading__secondary">Kontaktiere Uns</h2>
+		<h2 class="heading heading__secondary">
+			Kontaktiere Uns
+			<span class="kontakt__social">{{- partial "svgs/social_svgs.html" . -}}</span>
+		</h2>
 		<p class="kontakt__intro">
 			Bitte teilt uns mit falls ihr Fragen, Ideen, oder Anliegen habt.
 		</p>


### PR DESCRIPTION
Updated the form with the following additions:

**Social icons within the header**
![CleanShot 2020-09-02 at 17 23 51@2x](https://user-images.githubusercontent.com/16960228/92003606-c6569e80-ed30-11ea-9340-40e7d5b30bb5.png)

**Blank link for future /datenschutz page**
![CleanShot 2020-09-02 at 17 24 19@2x](https://user-images.githubusercontent.com/16960228/92003631-cd7dac80-ed30-11ea-8bf9-a305a76ce71f.png)
