### PR TITLE
Snippet fix

### DIFF
--- a/.forestry/snippets/definition.snippet
+++ b/.forestry/snippets/definition.snippet
@@ -1,1 +1,1 @@
-{{< definition wort="add word here" def=`add definition here` >}}
+{{< definition wort="add word here" def="add definition here" >}}

--- a/.forestry/snippets/image.snippet
+++ b/.forestry/snippets/image.snippet
@@ -1,1 +1,1 @@
-{{< image img=`add image name here` img_description="add image description here" img_src=`add image source link here` img_photographer="add image photographer here">}}
+{{< image img="add image name here" img_description="add image description here" img_src="add image source link here" img_photographer="add image photographer here">}}

--- a/assets/sass/components/_definition.scss
+++ b/assets/sass/components/_definition.scss
@@ -8,6 +8,7 @@
 	opacity: 0;
 	visibility: hidden;
 	transition: all .3s;
+	z-index: 9999;
 
 	&:target {
 		opacity: 1;


### PR DESCRIPTION
Updated Forestry snippets so that:
- Definition block has a higher `z-index` than the support-us partial; and
- Avoid code block highlighting within a snippet by swapping out backticks for double quotations.