### PR TITLE
Image snippet fix

### DIFF
--- a/.forestry/snippets/image.snippet
+++ b/.forestry/snippets/image.snippet
@@ -1,1 +1,6 @@
-{{< image img="add image name here" img_description="add image description here" img_src="add image source link here" img_photographer="add image photographer here">}}
+{{< image
+	img="add image name here"
+	img_description="add image description here"
+	img_src="add image source link here"
+	img_photographer="add image photographer here"
+>}}

--- a/content/wer-hilft-den-gestrandeten-kindern-von-moria.md
+++ b/content/wer-hilft-den-gestrandeten-kindern-von-moria.md
@@ -22,7 +22,12 @@ Viele Menschen, die in Moria gelandet sind, stecken fest. Sie kommen aus Syrien,
 
 {{< definition wort="Organisationen" def="Eine Organisation ist ein Unternehmen oder eine Gruppe, die nach bestimmten Strukturen geordnet und aufgebaut ist. Eine Hilfsorganisation ist eine Gruppe, die organisiert helfen möchte." >}}
 
-{{< image img="moria_camp_xplu5h.jpg" img_description="Refugee camp in Greece" img_src="https://unsplash.com/@jricard" img_photographer="Julie Ricard">}}
+{{< image
+	img="moria_camp_xplu5h.jpg"
+	img_description="Refugee camp in Greece"
+	img_src="https://unsplash.com/@jricard"
+	img_photographer="Julie Ricard"
+>}}
 
 Mehr als 21’000 Menschen leben im Flüchtlingslager Moria auf Lesbos. Geplant ist es für etwa 2800 Menschen, also deutlich weniger. Es fehlt an Wasser, an Lebensmittel, an Medikamenten. «Gewohnt» wird in einfachen Zelten ohne grössere Ausrüstung. Hauptsache, eine Plane über dem Kopf.
 


### PR DESCRIPTION
Made the image snippet multi-line to see if I can rid the odd behaviour with this tag in Forestry. Tested in localhost and this new structure did not break the image.