### PR TITLE
Img shortcode reversion

### DIFF
--- a/.forestry/snippets/image.snippet
+++ b/.forestry/snippets/image.snippet
@@ -1,4 +1,1 @@
-{{< image >}}
-	{{< photo img="" desc="" >}}
-	{{< caption photographer="" src="" >}}
-{{< /image >}}
+{{% image img="**Enter file ext. here**" desc="**Enter photo description here**" src="**Enter photo src here**" photographer="**Enter name here**" %}}

--- a/.forestry/snippets/image.snippet
+++ b/.forestry/snippets/image.snippet
@@ -1,1 +1,1 @@
-{{% image img="**Enter file ext. here**" desc="**Enter photo description here**" src="**Enter photo src here**" photographer="**Enter name here**" %}}
+{{< image img="Enter file with ext. here" desc="Enter photo description here" src="Enter photo src here" photographer="Enter name here" >}}

--- a/content/das-fest-der-spende-und-zusammenkunft-in-der-krise.md
+++ b/content/das-fest-der-spende-und-zusammenkunft-in-der-krise.md
@@ -22,7 +22,7 @@ Die Muslimen glauben ebenfalls an einen Gott. Diesen nennen sie “Allah”. Auc
 
 Der Ramadan ist der neunte Monat im islamischen Mondkalender und dauert 30 Tage. Während dieser Zeit fasten die Muslime. Sie essen und trinken nur zwischen Sonnenuntergang und Sonnenaufgang. Sie trinken in dieser Zeit auch kein Wasser. Das Fasten gehört zu den Hauptpflichten der Muslimen. Allerdings sind schwangere Frauen, Kinder bis 14 Jahre und ältere und kranke Menschen ausgenommen. Sie müssen nicht fasten. Ramadan kommt vom arabischen Wort “ramida” und heisst “brennende Hitze und Trockenheit”. Diese Bedeutung bezieht sich auf das Gefühl des Magens. Während des Ramadans brennt der Magen des Fastenden – er ist leer und trocken. Das Ziel dieser Zeit ist die Reinigung des Körpers und der Seele. Daneben ist das Zusammenleben und das Spenden an andere sehr wichtig. In dieser Zeit erinnern sich die Personen, die fasten, daran was sie haben. Sie lernen es noch mehr zu schätzen. Bei Sonnenuntergang beginnt das Essen. Immer begleitet vom Beten. Dabei isst und trinkt man oft mit Freunden und vor allem auch ausgewogen. Nur so können die Menschen wieder rund 16 Stunden nichts essen und trinken.
 
-{{< image >}} {{< photo img="ramadan-2_bdhu5t.jpg" desc="The Quran" >}} {{< caption photographer="Masjid Pogung Dalangan" src="https://unsplash.com/@masjidmpd" >}} {{< /image >}}
+{{< image img="ramadan-2_bdhu5t.jpg" desc="Golden embroidered Quran" src="https://unsplash.com/@masjidmpd" photographer="Masjid Pogung Dalangan" >}}
 
 ## Ramadan und Coronavirus
 

--- a/content/im-mannerhockey-hat-nun-eine-frau-das-sagen.md
+++ b/content/im-mannerhockey-hat-nun-eine-frau-das-sagen.md
@@ -28,7 +28,7 @@ Der Fussball ist weltweit berühmter und beliebter als Eishockey, weshalb vielle
 
 ​In der Schweiz kannte man vor vielen Jahren ein Beispiel, das einem Verein auf die Beine geholfen und ihn zu vielen Erfolgen geführt hat: Gigi Oeri. Sie hat viel Geld investiert, um den FC Basel zu dem zu machen, wofür man ihn kennt und fürchtet. Ansonsten Frauen in der Chefetage? Fehlanzeige.
 
-{{< image >}} {{< photo img="frauen-im-maennersport-2_m5qjnu.jpg" desc="two women footballers fight for the ball" >}} {{< caption photographer="Jeffrey F Lin" src="https://unsplash.com/@jeffreyflin" >}} {{< /image >}}
+{{< image img="frauen-im-maennersport-2_m5qjnu.jpg" desc="two women footballers fight for the ball" src="https://unsplash.com/@jeffreyflin" photographer="Jeffrey F Lin" >}}
 
 In Deutschland sieht das ähnlich aus. Es gibt zwei bekannte Frauen, die im Verwaltungsrat sitzen. Wiebke Gorny bei Red Bull Leipzig und Sandra Schwedler beim FC St. Pauli.
 

--- a/content/wer-hilft-den-gestrandeten-kindern-von-moria.md
+++ b/content/wer-hilft-den-gestrandeten-kindern-von-moria.md
@@ -22,10 +22,7 @@ Viele Menschen, die in Moria gelandet sind, stecken fest. Sie kommen aus Syrien,
 
 {{< definition wort="Organisationen" def="Eine Organisation ist ein Unternehmen oder eine Gruppe, die nach bestimmten Strukturen geordnet und aufgebaut ist. Eine Hilfsorganisation ist eine Gruppe, die organisiert helfen möchte." >}}
 
-{{< image >}}
-	{{< photo img="moria_camp_xplu5h.jpg" desc="Refugee camp in Greece" >}}
-	{{< caption photographer="Julie Ricard" src="https://unsplash.com@jricard" >}}
-{{< /image >}}
+{{< image img="moria_camp_xplu5h.jpg" desc="Refugee camp in Greece" src="https://unsplash.com@jricard" photographer="Julie Ricard" >}}
 
 Mehr als 21’000 Menschen leben im Flüchtlingslager Moria auf Lesbos. Geplant ist es für etwa 2800 Menschen, also deutlich weniger. Es fehlt an Wasser, an Lebensmittel, an Medikamenten. «Gewohnt» wird in einfachen Zelten ohne grössere Ausrüstung. Hauptsache, eine Plane über dem Kopf.
 

--- a/layouts/shortcodes/caption.html
+++ b/layouts/shortcodes/caption.html
@@ -1,6 +1,0 @@
-<figcaption class="image__caption">
-	{{ partial "svgs/triangle_svg.html" (dict "fill" "#000" "width" 15 "height" 15) }}
-	<a href="{{ .Get `src` }}" target="_blank" class="image__src">
-		<div class="image__photographer">@{{ .Get "photographer" }}</div>
-	</a>
-</figcaption>

--- a/layouts/shortcodes/image.html
+++ b/layouts/shortcodes/image.html
@@ -1,1 +1,9 @@
-<figure class="image">{{ .Inner }}</figure>
+<figure class="image">
+	<img src="{{ .Site.Params.cloudinary_url }}/c_scale,q_auto:good,w_500/{{ .Get `img` }}" alt="{{ .Get `desc` }}" class="image__img">
+	<figcaption class="image__caption">
+		{{ partial "svgs/triangle_svg.html" (dict "fill" "#000" "width" 15 "height" 15) }}
+		<a href="{{ .Get `src` }}" target="_blank" class="image__src">
+			<div class="image__photographer">@{{ .Get "photographer" }}</div>
+		</a>
+	</figcaption>
+</figure>

--- a/layouts/shortcodes/photo.html
+++ b/layouts/shortcodes/photo.html
@@ -1,1 +1,0 @@
-<img src="{{ .Site.Params.cloudinary_url }}/c_scale,q_auto:good,w_500/{{ .Get `img` }}" alt="{{ .Get `desc` }}" class="image__img">


### PR DESCRIPTION
Final revision to the image shortcode. Turns out the issue stemmed from images with names than included an underscore before the cloudinary extension.