### PR TITLE
Main list page

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -8,8 +8,8 @@ hero_img:
 img_description:
 img_photographer:
 img_src:
-categories: []
-tags: []
+kategorien: []
+markierungen: []
 fdw: false
 paid: false
 artikel: true

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -12,5 +12,6 @@ categories: []
 tags: []
 fdw: false
 paid: false
+artikel: true
 draft: true
 ---

--- a/config.toml
+++ b/config.toml
@@ -3,5 +3,8 @@ languageCode = "de"
 title = "Chinderzytig - Die Zeitung für Kinder und Jungendliche"
 disqusShortname = "chinderzytig"
 [params]
-    DateForm = "2.01.2006"
-		cloudinary_url = "https://res.cloudinary.com/chinderzytig/image/upload"
+	DateForm = "2.01.2006"
+	cloudinary_url = "https://res.cloudinary.com/chinderzytig/image/upload"
+[taxonomies]
+	katagorie = "kategorien"
+	markierung = "markierungen"

--- a/content/abonnemente.md
+++ b/content/abonnemente.md
@@ -1,4 +1,5 @@
 ---
 title: "Abonnemente"
 layout: abonnemente
+artikel: false
 ---

--- a/content/alle-artikel.md
+++ b/content/alle-artikel.md
@@ -1,4 +1,5 @@
 ---
 title: "Alle Artikel"
 layout: alle-artikel
+artikel: false
 ---

--- a/content/alle-artikel.md
+++ b/content/alle-artikel.md
@@ -1,0 +1,4 @@
+---
+title: "Alle Artikel"
+layout: alle-artikel
+---

--- a/content/coronavirus.md
+++ b/content/coronavirus.md
@@ -1,11 +1,11 @@
 ---
 title: Ein Virus versetzt die Welt in Aufruhr
 slug: coronavirus
-description: 
+description:
 date: 2020-02-23T16:54:31.000+02:00
-author: 
+author:
 hero_img: coronavirus_rgdsvi.jpg
-img_description: 
+img_description:
 img_photographer: Waldemar Brandt
 img_src: https://unsplash.com/@waldemarbrandt67w?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText
 categories:
@@ -15,7 +15,7 @@ tags:
 - COVID-19
 fdw: false
 paid: false
-
+artikel: true
 ---
 Nach wie vor beschäftigt sich die Menschheit mit dem Corona-Virus. Ein kleines,
 unsichtbares Ding, das sich (noch) nicht bekämpfen lässt und von Mensch zu

--- a/content/coronavirus.md
+++ b/content/coronavirus.md
@@ -8,10 +8,10 @@ hero_img: coronavirus_rgdsvi.jpg
 img_description:
 img_photographer: Waldemar Brandt
 img_src: https://unsplash.com/@waldemarbrandt67w?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText
-categories:
+kategorien:
 - Gesundheit
 - Welt
-tags:
+markierungen:
 - COVID-19
 fdw: false
 paid: false

--- a/content/das-fest-der-spende-und-zusammenkunft-in-der-krise.md
+++ b/content/das-fest-der-spende-und-zusammenkunft-in-der-krise.md
@@ -1,4 +1,5 @@
 +++
+artikel = true
 author = "Seraina Branschi"
 categories = ["Welt", "Gesellschaft"]
 date = 2020-04-21T23:00:00Z

--- a/content/das-fest-der-spende-und-zusammenkunft-in-der-krise.md
+++ b/content/das-fest-der-spende-und-zusammenkunft-in-der-krise.md
@@ -1,7 +1,7 @@
 +++
 artikel = true
 author = "Seraina Branschi"
-categories = ["Welt", "Gesellschaft"]
+kategorien = ["Welt", "Gesellschaft"]
 date = 2020-04-21T23:00:00Z
 description = ""
 fdw = false
@@ -11,7 +11,7 @@ img_photographer = "Levi Clancy"
 img_src = "https://unsplash.com/@leviclancy"
 paid = false
 slug = "ramadan"
-tags = [" Religion / Tradition"]
+markierungen = [" Religion / Tradition"]
 title = "Das Fest der Spende und Zusammenkunft – in der Krise?"
 
 +++

--- a/content/fokus-der-woche.md
+++ b/content/fokus-der-woche.md
@@ -1,4 +1,5 @@
 ---
 title: "Fokus der Woche"
 layout: fokus-der-woche
+artikel: false
 ---

--- a/content/grossbritannien-und-die-eu-gehen-getrennte-wege.md
+++ b/content/grossbritannien-und-die-eu-gehen-getrennte-wege.md
@@ -1,4 +1,5 @@
 +++
+artikel = true
 author = ""
 categories = ["Politik"]
 date = 2020-02-02T00:00:00Z

--- a/content/grossbritannien-und-die-eu-gehen-getrennte-wege.md
+++ b/content/grossbritannien-und-die-eu-gehen-getrennte-wege.md
@@ -1,7 +1,7 @@
 +++
 artikel = true
 author = ""
-categories = ["Politik"]
+kategorien = ["Politik"]
 date = 2020-02-02T00:00:00Z
 description = ""
 fdw = false
@@ -11,7 +11,7 @@ img_photographer = "Jannes Van den wouwer"
 img_src = "https://unsplash.com/@jannesvdw"
 paid = false
 slug = "brexitisreal"
-tags = ["Europa"]
+markierungen = ["Europa"]
 title = "Grossbritannien und die EU gehen getrennte Wege"
 
 +++

--- a/content/im-mannerhockey-hat-nun-eine-frau-das-sagen.md
+++ b/content/im-mannerhockey-hat-nun-eine-frau-das-sagen.md
@@ -1,7 +1,7 @@
 +++
 artikel = true
 author = "Lars Ziörjen"
-categories = ["Europa", "Gesellschaft"]
+kategorien = ["Europa", "Gesellschaft"]
 date = 2020-05-27T23:00:00Z
 description = ""
 fdw = false
@@ -11,7 +11,7 @@ img_photographer = "Jerry Yu"
 img_src = "https://unsplash.com/@jerryyu"
 paid = false
 slug = "frauen-im-maennersport"
-tags = ["Schweiz", "Rechte"]
+markierungen = ["Schweiz", "Rechte"]
 title = "Im Männerhockey hat nun eine Frau das Sagen"
 
 +++

--- a/content/im-mannerhockey-hat-nun-eine-frau-das-sagen.md
+++ b/content/im-mannerhockey-hat-nun-eine-frau-das-sagen.md
@@ -1,4 +1,5 @@
 +++
+artikel = true
 author = "Lars Ziörjen"
 categories = ["Europa", "Gesellschaft"]
 date = 2020-05-27T23:00:00Z

--- a/content/kinder-in-not-hier-wird-dir-geholfen.md
+++ b/content/kinder-in-not-hier-wird-dir-geholfen.md
@@ -1,7 +1,7 @@
 +++
 artikel = true
 author = "Lars Ziörjen"
-categories = ["Europa", "Gesellschaft"]
+kategorien = ["Europa", "Gesellschaft"]
 date = 2020-04-19T23:00:00Z
 description = ""
 fdw = false
@@ -11,7 +11,7 @@ img_photographer = "Emiliano Vittoriosi"
 img_src = "https://unsplash.com/@emilianovittoriosi"
 paid = false
 slug = "kinderhilfe"
-tags = ["Schweiz", "Soziales"]
+markierungen = ["Schweiz", "Soziales"]
 title = "Kinder in Not - hier wird dir geholfen"
 
 +++

--- a/content/kinder-in-not-hier-wird-dir-geholfen.md
+++ b/content/kinder-in-not-hier-wird-dir-geholfen.md
@@ -1,4 +1,5 @@
 +++
+artikel = true
 author = "Lars Ziörjen"
 categories = ["Europa", "Gesellschaft"]
 date = 2020-04-19T23:00:00Z

--- a/content/kontakt.md
+++ b/content/kontakt.md
@@ -1,4 +1,5 @@
 ---
 title: "Kontakt"
 layout: kontakt
+artikel: false
 ---

--- a/content/nach-dem-brexit-folgte-der-megxit.md
+++ b/content/nach-dem-brexit-folgte-der-megxit.md
@@ -1,7 +1,7 @@
 +++
 artikel = true
 author = "Sarinia Branschi"
-categories = ["Gesellschaft"]
+kategorien = ["Gesellschaft"]
 date = 2020-05-18T23:00:00Z
 description = ""
 fdw = false
@@ -11,7 +11,7 @@ img_photographer = "King's Church International"
 img_src = "https://unsplash.com/@kingschurchinternational"
 paid = false
 slug = "megxit"
-tags = ["Großbritannien", "Personen"]
+markierungen = ["Großbritannien", "Personen"]
 title = "Nach dem Brexit folgte der Megxit"
 
 +++

--- a/content/nach-dem-brexit-folgte-der-megxit.md
+++ b/content/nach-dem-brexit-folgte-der-megxit.md
@@ -1,4 +1,5 @@
 +++
+artikel = true
 author = "Sarinia Branschi"
 categories = ["Gesellschaft"]
 date = 2020-05-18T23:00:00Z

--- a/content/unser-beirat.md
+++ b/content/unser-beirat.md
@@ -1,4 +1,5 @@
 ---
 title: "Unser Beirat"
 layout: unser-beirat
+artikel: false
 ---

--- a/content/unsere-geschichte.md
+++ b/content/unsere-geschichte.md
@@ -1,6 +1,7 @@
 ---
 title: "Unsere Geschichte"
 layout: unsere-geschichte
+artikel: false
 ---
 
 Die Idee von chinderzytig.ch sowie von [jugendzytig.ch](https://www.jugendzytig.ch/)

--- a/content/unsere-quellen.md
+++ b/content/unsere-quellen.md
@@ -1,4 +1,5 @@
 ---
 title: "Unsere Quellen"
 layout: unsere-quellen
+artikel: false
 ---

--- a/content/verein.md
+++ b/content/verein.md
@@ -1,4 +1,5 @@
 ---
 title: "Verein"
 layout: verein
+artikel: false
 ---

--- a/content/wer-hilft-den-gestrandeten-kindern-von-moria.md
+++ b/content/wer-hilft-den-gestrandeten-kindern-von-moria.md
@@ -1,7 +1,7 @@
 +++
 artikel = true
 author = ""
-kategorien = ["Gesellschaft"]
+kategorien = ["Gesellschaft", "Europa"]
 date = 2020-01-05T00:00:00Z
 description = ""
 fdw = false
@@ -11,7 +11,7 @@ img_photographer = "Siddhant Soni"
 img_src = "https://unsplash.com/@52nd_"
 paid = false
 slug = "kinder-von-moria"
-markierungen = ["Migration"]
+markierungen = ["Migration", "Griechenland"]
 title = "Wer hilft den gestrandeten Kindern von Moria?"
 
 +++

--- a/content/wer-hilft-den-gestrandeten-kindern-von-moria.md
+++ b/content/wer-hilft-den-gestrandeten-kindern-von-moria.md
@@ -1,7 +1,7 @@
 +++
 artikel = true
 author = ""
-categories = ["Gesellschaft"]
+kategorien = ["Gesellschaft"]
 date = 2020-01-05T00:00:00Z
 description = ""
 fdw = false
@@ -11,7 +11,7 @@ img_photographer = "Siddhant Soni"
 img_src = "https://unsplash.com/@52nd_"
 paid = false
 slug = "kinder-von-moria"
-tags = ["Migration"]
+markierungen = ["Migration"]
 title = "Wer hilft den gestrandeten Kindern von Moria?"
 
 +++

--- a/content/wer-hilft-den-gestrandeten-kindern-von-moria.md
+++ b/content/wer-hilft-den-gestrandeten-kindern-von-moria.md
@@ -1,4 +1,5 @@
 +++
+artikel = true
 author = ""
 categories = ["Gesellschaft"]
 date = 2020-01-05T00:00:00Z

--- a/content/über-uns.md
+++ b/content/über-uns.md
@@ -1,4 +1,5 @@
 ---
 title: "Über Uns"
 layout: über-uns
+artikel: false
 ---

--- a/layouts/_default/alle-artikel.html
+++ b/layouts/_default/alle-artikel.html
@@ -2,8 +2,8 @@
 	<section class="taxonomy">
 		<h3 class="heading heading--taxonomy">Artikel Kategorien</h3>
 		<div class="taxonomy__markers">
-			{{range $name, $taxonomy := .Site.Taxonomies.categories}}
-				{{ with $.Site.GetPage (printf "/categories/%s" $name) }}
+			{{range $name, $taxonomy := .Site.Taxonomies.kategorien}}
+				{{ with $.Site.GetPage (printf "/kategorien/%s" $name) }}
 					<a href="{{ .Permalink }}" class="marker marker--list">{{ humanize $name }}</a>
 				{{end}}
 			{{end}}

--- a/layouts/_default/alle-artikel.html
+++ b/layouts/_default/alle-artikel.html
@@ -1,0 +1,27 @@
+{{define "main"}}
+	<section class="taxonomy">
+		<h3 class="heading heading--taxonomy">Artikel Kategorien</h3>
+		<div class="taxonomy__markers">
+			{{range $name, $taxonomy := .Site.Taxonomies.categories}}
+				{{ with $.Site.GetPage (printf "/categories/%s" $name) }}
+					<a href="{{ .Permalink }}" class="marker marker--list">{{ humanize $name }}</a>
+				{{end}}
+			{{end}}
+		</div>
+	</section>
+
+	<section class="card__list">
+		<h2 class="heading heading__secondary">{{ .Title }}</h2>
+		<div class="card__container">
+			{{ range where (where .Site.Pages ".Params.artikel" true) ".Params.fdw" false }}
+				<a href="{{.RelPermalink}}" class="card card--grey">
+					<div style="background:url({{ .Site.Params.cloudinary_url }}/c_scale,h_170,w_300,q_auto:good/{{ .Params.hero_img }})" class="card__photo"></div>
+					<div class="card__content">
+						<h3 class="card__content-title">{{ .Title }}</h3>
+						<div class="card__content-date">{{ .Date.Format .Site.Params.DateForm }}</div>
+					</div>
+				</a>
+			{{ end }}
+		</div>
+	</section>
+{{ end }}

--- a/layouts/_default/alle-artikel.html
+++ b/layouts/_default/alle-artikel.html
@@ -13,7 +13,8 @@
 	<section class="card__list">
 		<h2 class="heading heading__secondary">{{ .Title }}</h2>
 		<div class="card__container">
-			{{ range where (where .Site.Pages ".Params.artikel" true) ".Params.fdw" false }}
+			{{ $artikel := where (where .Site.Pages ".Params.artikel" true) ".Params.fdw" false }}
+			{{ range $artikel.ByTitle }}
 				<a href="{{.RelPermalink}}" class="card card--grey">
 					<div style="background:url({{ .Site.Params.cloudinary_url }}/c_scale,h_170,w_300,q_auto:good/{{ .Params.hero_img }})" class="card__photo"></div>
 					<div class="card__content">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -11,14 +11,14 @@
 				</figcaption>
 			</figure>
 			<div class="single__taxonomies">
-				{{ if .Params.categories }}
-					{{ range .Params.categories }}
-						<a href="{{ "/categories" | relLangURL }}/{{ . | urlize }}" class="marker marker--article">{{ . }}</a>
+				{{ if .Params.kategorien }}
+					{{ range (.GetTerms "kategorien") }}
+						<a href="{{ .Permalink }}" class="marker marker--article">{{ .LinkTitle }}</a>
 					{{ end }}
 				{{ end }}
-				{{ if .Params.tags}}
-					{{ range .Params.tags }}
-						<a href="{{ "/tags" | relLangURL }}/{{ . | urlize }}" class="marker marker--article">{{ . }}</a>
+				{{ if .Params.markierungen }}
+					{{ range (.GetTerms "markierungen") }}
+						<a href="{{ .Permalink }}" class="marker marker--article">{{ .LinkTitle }}</a>
 					{{ end }}
 				{{ end }}
 			</div>

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -3,14 +3,14 @@
 		{{ $link := string .Permalink }}
 
 		{{ range .Pages.ByLinkTitle.Reverse }}
-			{{ range (.GetTerms "tags") }}
+			{{ range (.GetTerms "markierungen") }}
 				{{ $tags = $tags | append . }}
 			{{ end }}
 		{{ end }}
 
 		{{ $tags = $tags | uniq }}
 
-		{{ if in $link "categories"}}
+		{{ if in $link "kategorien"}}
 			<section class="taxonomy">
 				<h3 class="heading heading--taxonomy">{{ .Title }} Markierungen</h3>
 				<div class="taxonomy__markers">

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -34,6 +34,5 @@
 				</a>
 			{{ end }}
 		</div>
-		<p></p>
 	</section>
 {{end}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -38,30 +38,19 @@
 	<section class="new__cta card__list">
 		<h2 class="heading heading__secondary">Neuste Artikel</h2>
 		<div class="card__container">
-			<a href="#" class="card card--grey">
-				<div style="background:url(https://res.cloudinary.com/chinderzytig/image/upload/c_scale,h_170,w_300,q_auto:good/v1594824172/article_imgs/app_rkukid.jpg)" class="card__photo"></div>
-				<div class="card__content">
-					<h3 class="card__content-title">Verfolgt oder einfach beschützt? What it looks like with a longer title</h3>
-					<div class="card__content-date">07.15</div>
-				</div>
-			</a>
-			<a href="#" class="card card--grey">
-				<div style="background:url(https://res.cloudinary.com/chinderzytig/image/upload/c_scale,h_170,w_300,q_auto:good/v1594824172/article_imgs/app_rkukid.jpg)" class="card__photo"></div>
-				<div class="card__content">
-					<h3 class="card__content-title">Verfolgt oder einfach beschützt? What it looks like with a longer title</h3>
-					<div class="card__content-date">07.15</div>
-				</div>
-			</a>
-			<a href="#" class="card card--grey">
-				<div style="background:url(https://res.cloudinary.com/chinderzytig/image/upload/c_scale,h_170,w_300,q_auto:good/v1594824172/article_imgs/app_rkukid.jpg)" class="card__photo"></div>
-				<div class="card__content">
-					<h3 class="card__content-title">Verfolgt oder einfach beschützt? What it looks like with a longer title</h3>
-					<div class="card__content-date">07.15</div>
-				</div>
-			</a>
+			{{ $artikel := where (where .Site.Pages ".Params.artikel" true) ".Params.fdw" false }}
+			{{ range first 6 $artikel.ByDate }}
+				<a href="{{.RelPermalink}}" class="card card--grey">
+					<div style="background:url({{ .Site.Params.cloudinary_url }}/c_scale,h_170,w_300,q_auto:good/{{ .Params.hero_img }})" class="card__photo"></div>
+					<div class="card__content">
+						<h3 class="card__content-title">{{ .Title }}</h3>
+						<div class="card__content-date">{{ .Date.Format .Site.Params.DateForm }}</div>
+					</div>
+				</a>
+			{{ end }}
 		</div>
 		<div class="btn__container">
-			<a href="#" class="btn btn--primary">Alle Artikel</a>
+			<a href="/alle-artikel" class="btn btn--primary">Alle Artikel</a>
 		</div>
 	</section>
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -14,7 +14,7 @@
 	<div class="footer__middle">
 		<div class="footer__middle-container">
 			<ul class="footer__column footer__column--heavy">
-				<li class="footer__column-item"><a href="#" class="footer__column-link">Artikel</a></li>
+				<li class="footer__column-item"><a href="/alle-artikel" class="footer__column-link">Artikel</a></li>
 				<li class="footer__column-item"><a href="/fokus-der-woche" class="footer__column-link">Fokus der Woche</a></li>
 				<li class="footer__column-item"><a href="/abonnemente" class="footer__column-link">Abonnemente</a></li>
 				<li class="footer__column-item"><a href="/verein" class="footer__column-link">Der Verein</a></li>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -16,7 +16,7 @@
 	</div>
 	<div class="nav__menu">
 		<ul class="nav__menu-group">
-			<a href="#" class="nav__menu-link"><li>Artikel</li></a>
+			<a href="/alle-artikel" class="nav__menu-link"><li>Artikel</li></a>
 			<a href="/fokus-der-woche" class="nav__menu-link"><li>Fokus der Woche</li></a>
 			<a href="/abonnemente" class="nav__menu-link"><li>Abonnemente</li></a>
 			<a href="/verein" class="nav__menu-link"><li>Der Verein</li></a>


### PR DESCRIPTION
Created main list page for all articles listed by title (alphabetical) as requested. This shares the same look and feel as the taxonomy template, but lists all the articles present on Chinderzytig.

![CleanShot 2020-09-14 at 20 14 22@2x](https://user-images.githubusercontent.com/16960228/93122570-028de580-f6c7-11ea-8455-55de8ae0ff37.png)

Updated the homepage to reflect the newest articles...of course they are not the newest as I am just going down the list. But it will update automatically as I add more and more articles.

<img width="1105" alt="CleanShot 2020-09-14 at 20 14 39@2x" src="https://user-images.githubusercontent.com/16960228/93122578-06ba0300-f6c7-11ea-8151-b41c53c09887.png">

Also updated the taxonomies in the `config.toml file`. Instead of showing www.chinderzytig.ch/categories/... or www.chinderzytig.ch/tags/..., it will now show www.chinderzytig.ch/kategorien/.... and www.chinderzytig.ch/markierungen/...