### PR TITLE
Coronavirus section

### DIFF
--- a/.forestry/snippets/arbeitsmaterial-container.snippet
+++ b/.forestry/snippets/arbeitsmaterial-container.snippet
@@ -1,3 +1,0 @@
-{{< arbeitsmaterial-container >}}
-	{{< arbeitsmaterial file="add file name here" >}}
-{{< /arbeitsmaterial-container >}}

--- a/.forestry/snippets/arbeitsmaterial.snippet
+++ b/.forestry/snippets/arbeitsmaterial.snippet
@@ -1,1 +1,3 @@
-{{< arbeitsmaterial file="add file name here" >}}
+{{< arbeitsmaterial-container >}}
+	{{< arbeitsmaterial file="add file name here" img="add same file with .png" >}}
+{{< /arbeitsmaterial-container >}}

--- a/assets/sass/base/_typography.scss
+++ b/assets/sass/base/_typography.scss
@@ -72,7 +72,6 @@ body {
 			font-family: $font-patrick, $font-fallback;
 			font-size: $font-big;
 			font-weight: 700;
-			text-align: justify;
 
 			&--highlight {
 				font-family: $font-patrick, $font-fallback;

--- a/content/keine-corona-infizierten-in-nordkorea.md
+++ b/content/keine-corona-infizierten-in-nordkorea.md
@@ -50,4 +50,6 @@ Abbildungen 1 und 2: [https://www.dw.com/de/coronavirus-ist-nordkorea-virenfrei/
 
 ## Arbeitsmaterial
 
-{{< arbeitsmaterial file="nordkorea-und-corona-arbeitsmaterial_ofbj21.pdf" >}}
+{{< arbeitsmaterial-container >}}
+	{{< arbeitsmaterial file="nordkorea-und-corona-arbeitsmaterial_ofbj21.pdf" img="nordkorea-und-corona-arbeitsmaterial_ofbj21.png" >}}
+{{< /arbeitsmaterial-container >}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -7,30 +7,18 @@
 		<div class="card__list">
 			<h2 class="heading heading__tertiary">Coronavirus</h2>
 			<div class="card__container">
-				<a href="#" class="card card--white">
-					<div style="background:url(https://res.cloudinary.com/chinderzytig/image/upload/c_scale,h_170,w_300,q_auto:good/v1594824172/article_imgs/app_rkukid.jpg)" class="card__photo"></div>
-					<div class="card__content">
-						<h3 class="card__content-title">Verfolgt oder einfach beschützt? What it looks like with a longer title</h3>
-						<div class="card__content-date">07.15</div>
-					</div>
-				</a>
-				<a href="#" class="card card--white">
-					<div style="background:url(https://res.cloudinary.com/chinderzytig/image/upload/c_scale,h_170,w_300,q_auto:good/v1594824172/article_imgs/app_rkukid.jpg)" class="card__photo"></div>
-					<div class="card__content">
-						<h3 class="card__content-title">Verfolgt oder einfach beschützt? What it looks like with a longer title</h3>
-						<div class="card__content-date">07.15</div>
-					</div>
-				</a>
-				<a href="#" class="card card--white">
-					<div style="background:url(https://res.cloudinary.com/chinderzytig/image/upload/c_scale,h_170,w_300,q_auto:good/v1594824172/article_imgs/app_rkukid.jpg)" class="card__photo"></div>
-					<div class="card__content">
-						<h3 class="card__content-title">Verfolgt oder einfach beschützt? What it looks like with a longer title</h3>
-						<div class="card__content-date">07.15</div>
-					</div>
-				</a>
+				{{ range first 3 (index .Site.Taxonomies.markierungen "covid-19") }}
+					<a href="{{.RelPermalink}}" class="card card--white">
+						<div style="background:url({{ .Site.Params.cloudinary_url }}/c_scale,h_170,w_300,q_auto:good/{{ .Params.hero_img }})" class="card__photo"></div>
+						<div class="card__content">
+							<h3 class="card__content-title">{{ .Title }}</h3>
+							<div class="card__content-date">{{ .Date.Format .Site.Params.DateForm }}</div>
+						</div>
+					</a>
+				{{ end }}
 			</div>
 			<div class="btn__container">
-				<a href="#" class="btn btn--secondary">Mehr Artikel</a>
+				<a href="/markierungen/covid-19" class="btn btn--secondary">Mehr Artikel</a>
 			</div>
 		</div>
 	</section>

--- a/layouts/shortcodes/arbeitsmaterial.html
+++ b/layouts/shortcodes/arbeitsmaterial.html
@@ -1,6 +1,6 @@
 <div class="arbeitsmaterial">
-	<a href="{{ .Site.Params.cloudinary_url }}/{{ .Get `file`}}" class="arbeitsmaterial__link">
-		<img src="{{ .Site.Params.cloudinary_url }}/c_scale,h_200,q_auto:best/{{ .Get `file`}}" alt="" class="arbeitsmaterial__file">
+	<a href="{{ .Site.Params.cloudinary_url }}/{{ .Get `file`}}" target="_blank" class="arbeitsmaterial__link">
+		<img src="{{ .Site.Params.cloudinary_url }}/bo_1px_solid_rgb:000000,c_scale,h_200,q_auto:best/{{ .Get `img`}}" alt="Arbeitsmaterial cover" class="arbeitsmaterial__file">
 		<div class="arbeitsmaterial__file-name">{{ .Get "file"}}</div>
 	</a>
 </div>


### PR DESCRIPTION
The Coronavirus section on the homepage now displays the first three articles from the markierung: COVID-19 (newest to oldest):

![CleanShot 2020-09-15 at 12 00 10](https://user-images.githubusercontent.com/16960228/93197012-6e199680-f74b-11ea-9a0a-000839375fb9.gif)

Also, fixed the arbeitsmaterial snippet by adding a file for the PDF image. Wasn't working as the img tag was trying to display a file with a .pdf extension.