### PR TITLE
Fix lookup rules warning

### DIFF
--- a/assets/sass/base/_typography.scss
+++ b/assets/sass/base/_typography.scss
@@ -140,7 +140,7 @@ body {
 		margin-bottom: 1.5rem;
 	}
 
-	&--taxonomy {
+	&--list {
 		color: $social-base;
 		background-color: $color-white;
 		font-size: 2.5rem;

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -27,8 +27,8 @@
 @import "pages/fokus_der_woche";
 @import "pages/index";
 @import "pages/kontakt";
+@import "pages/list";
 @import "pages/single";
-@import "pages/taxonomy";
 @import "pages/über-uns";
 @import "pages/unser-beirat";
 @import "pages/unsere-geschichte";

--- a/assets/sass/pages/_list.scss
+++ b/assets/sass/pages/_list.scss
@@ -1,4 +1,4 @@
-.taxonomy {
+.list {
 	@include container-main;
 
 	&__markers {

--- a/layouts/_default/alle-artikel.html
+++ b/layouts/_default/alle-artikel.html
@@ -1,7 +1,7 @@
 {{define "main"}}
-	<section class="taxonomy">
-		<h3 class="heading heading--taxonomy">Artikel Kategorien</h3>
-		<div class="taxonomy__markers">
+	<section class="list">
+		<h3 class="heading heading--list">Artikel Kategorien</h3>
+		<div class="list__markers">
 			{{range $name, $taxonomy := .Site.Taxonomies.kategorien}}
 				{{ with $.Site.GetPage (printf "/kategorien/%s" $name) }}
 					<a href="{{ .Permalink }}" class="marker marker--list">{{ humanize $name }}</a>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -11,9 +11,9 @@
 		{{ $tags = $tags | uniq }}
 
 		{{ if in $link "kategorien"}}
-			<section class="taxonomy">
-				<h3 class="heading heading--taxonomy">{{ .Title }} Markierungen</h3>
-				<div class="taxonomy__markers">
+			<section class="list">
+				<h3 class="heading heading--list">{{ .Title }} Markierungen</h3>
+				<div class="list__markers">
 					{{ range $tags }}
 					<a href="{{ .Permalink }}" class="marker marker--list">{{ .LinkTitle }}</a>
 					{{ end }}


### PR DESCRIPTION
`WARN 2020/09/16 09:17:43 found no layout file for "HTML" for kind "taxonomyTerm": You should create a template file which matches Hugo Layouts Lookup Rules for this combination.`

As per this error, I needed to change `taxonomy.html` to `list.html` in order to comply with Hugo's layouts lookup rules. For the record, I had started with list.html in order to comply but this default template was not rendering my taxonomy lists...now this has appeared to have corrected itself.