### PR TITLE
"Mehr Article" button functionality

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -2,4 +2,19 @@ $(document).ready(function() {
 	$("#js-scroll-to-comments").click(function() {
 		$('html, body').animate({scrollTop: $('.js-section-comments').offset().top}, 1000);
 	});
+
+	if($(".card__hidden:hidden").length < 6) {$("#loadMore").hide();}
+
+	$(".card__hidden").slice(0, 6).show();
+
+	$("#loadMore").on('click', function (e) {
+		e.preventDefault();
+
+		$(".card__hidden:hidden").slice(0, 6).slideDown();
+		if($(".card__hidden:hidden").length == 0) {
+			$("#loadMore").fadeOut();
+		}
+
+		$('html, body').animate({scrollTop: $().offset().top}, 1000);
+	});
 });

--- a/assets/sass/components/_card.scss
+++ b/assets/sass/components/_card.scss
@@ -33,4 +33,6 @@
 		flex-wrap: wrap;
 		margin-top: -3rem;
 	}
+
+	&__hidden { display: none; }
 }

--- a/layouts/_default/alle-artikel.html
+++ b/layouts/_default/alle-artikel.html
@@ -15,7 +15,7 @@
 		<div class="card__container">
 			{{ $artikel := where (where .Site.Pages ".Params.artikel" true) ".Params.fdw" false }}
 			{{ range $artikel.ByTitle }}
-				<a href="{{.RelPermalink}}" class="card card--grey">
+				<a href="{{.RelPermalink}}" class="card card--grey card__hidden">
 					<div style="background:url({{ .Site.Params.cloudinary_url }}/c_scale,h_170,w_300,q_auto:good/{{ .Params.hero_img }})" class="card__photo"></div>
 					<div class="card__content">
 						<h3 class="card__content-title">{{ .Title }}</h3>
@@ -23,6 +23,9 @@
 					</div>
 				</a>
 			{{ end }}
+		</div>
+		<div class="btn__container">
+			<a href="#" class="btn btn--primary" id="loadMore">Mehr Artikel</a>
 		</div>
 	</section>
 {{ end }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -25,7 +25,7 @@
 		<h2 class="heading heading__secondary">Alle Artikel: {{ .Title }}</h2>
 		<div class="card__container">
 			{{ range .Pages.ByTitle }}
-				<a href="{{.RelPermalink}}" class="card card--grey">
+				<a href="{{.RelPermalink}}" class="card card--grey card__hidden">
 					<div style="background:url({{ .Site.Params.cloudinary_url }}/c_scale,h_170,w_300,q_auto:good/{{ .Params.hero_img }})" class="card__photo"></div>
 					<div class="card__content">
 						<h3 class="card__content-title">{{ .Title }}</h3>
@@ -33,6 +33,9 @@
 					</div>
 				</a>
 			{{ end }}
+		</div>
+		<div class="btn__container">
+			<a href="#" class="btn btn--primary" id="loadMore">Mehr Artikel</a>
 		</div>
 	</section>
 {{end}}


### PR DESCRIPTION
List pages will now only display six articles max on page load. If a particular list page has more than six articles within its category or tag,  a "Mehr Artikel" button will be displayed under these articles.

Clicking the button will load another six articles per press until there are no hidden articles left. Once this is the case, the "Mehr Artikel" button will disappear.

![CleanShot 2020-09-16 at 11 05 33](https://user-images.githubusercontent.com/16960228/93317279-923dac00-f80d-11ea-8aa1-41d66687d780.gif)
