### PR TITLE
Arbeitsmaterial shortcode fix

### DIFF
--- a/.forestry/snippets/arbeitsmaterial.snippet
+++ b/.forestry/snippets/arbeitsmaterial.snippet
@@ -1,3 +1,3 @@
 {{< arbeitsmaterial-container >}}
-	{{< arbeitsmaterial file="add file name here" img="add same file with .png" >}}
+	{{< arbeitsmaterial file="add file name without extension" >}}
 {{< /arbeitsmaterial-container >}}

--- a/content/keine-corona-infizierten-in-nordkorea.md
+++ b/content/keine-corona-infizierten-in-nordkorea.md
@@ -51,5 +51,5 @@ Abbildungen 1 und 2: [https://www.dw.com/de/coronavirus-ist-nordkorea-virenfrei/
 ## Arbeitsmaterial
 
 {{< arbeitsmaterial-container >}}
-	{{< arbeitsmaterial file="nordkorea-und-corona-arbeitsmaterial_ofbj21.pdf" img="nordkorea-und-corona-arbeitsmaterial_ofbj21.png" >}}
+	{{< arbeitsmaterial file="nordkorea-und-corona-arbeitsmaterial_ofbj21" >}}
 {{< /arbeitsmaterial-container >}}

--- a/content/seit-fast-70-jahren-fliegt-sie-durch-die-lufte.md
+++ b/content/seit-fast-70-jahren-fliegt-sie-durch-die-lufte.md
@@ -45,4 +45,4 @@ Rega Homepage: [https://www.rega.ch/](https://www.rega.ch/ "https://www.rega.ch/
 
 ## Arbeitsmaterial
 
-{{< arbeitsmaterial-container >}} {{< arbeitsmaterial file="rega-arbeitsmaterial_g35awb.pdf" img="rega-arbeitsmaterial_g35awb.png" >}} {{< /arbeitsmaterial-container >}}
+{{< arbeitsmaterial-container >}} {{< arbeitsmaterial file="rega-arbeitsmaterial_g35awb" >}} {{< /arbeitsmaterial-container >}}

--- a/content/wer-kann-lesen-und-schreiben.md
+++ b/content/wer-kann-lesen-und-schreiben.md
@@ -41,4 +41,4 @@ Am 8. September ist der Welttag der Alphabetisierung. An diesem Tag will die {{<
 
 ## Arbeitsmaterial
 
-{{< arbeitsmaterial-container >}} {{< arbeitsmaterial file="welt-alphabetisierungs-tag-arbeitsmateral_bsb4mx.pdf" img="welt-alphabetisierungs-tag-arbeitsmateral_bsb4mx.png" >}} {{< /arbeitsmaterial-container >}}
+{{< arbeitsmaterial-container >}} {{< arbeitsmaterial file="welt-alphabetisierungs-tag-arbeitsmateral_bsb4mx" >}} {{< /arbeitsmaterial-container >}}

--- a/layouts/shortcodes/arbeitsmaterial.html
+++ b/layouts/shortcodes/arbeitsmaterial.html
@@ -1,6 +1,6 @@
 <div class="arbeitsmaterial">
-	<a href="{{ .Site.Params.cloudinary_url }}/{{ .Get `file`}}" target="_blank" class="arbeitsmaterial__link">
-		<img src="{{ .Site.Params.cloudinary_url }}/bo_1px_solid_rgb:000000,c_scale,h_200,q_auto:best/{{ .Get `img`}}" alt="Arbeitsmaterial cover" class="arbeitsmaterial__file">
-		<div class="arbeitsmaterial__file-name">{{ .Get "file"}}</div>
+	<a href="{{ .Site.Params.cloudinary_url }}/{{ .Get `file`}}.pdf" target="_blank" class="arbeitsmaterial__link">
+		<img src="{{ .Site.Params.cloudinary_url }}/bo_1px_solid_rgb:000000,c_scale,h_200,q_auto:best/{{ .Get `file`}}.png" alt="Arbeitsmaterial cover" class="arbeitsmaterial__file">
+		<div class="arbeitsmaterial__file-name">{{ .Get "file"}}.png</div>
 	</a>
 </div>


### PR DESCRIPTION
Issues with the `arbeitsmaterial.snippet` when used in forestry, so I had to manually add the `.pdf` and `.png` file extensions to the respective sections within the shortcode. Now the file name without the extension only needs to be added to the snippet:

```
{{< arbeitsmaterial file="example-image_ox24c" >}}
```
in code this will convert to:
```
<a href="https://res.cloudinary.com/chinderzytig/image/upload/example-image_ox24c.pdf" target="_blank" class="arbeitsmaterial__link">
  <img src="https://res.cloudinary.com/chinderzytig/image/upload/c_scale,q_auto:good,w_800//v1600259539/example-image_ox24c.png">
</a>
```