### PR TITLE
Article card buffer

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -17,6 +17,6 @@ $(document).ready(function() {
 			$("#loadMore").fadeOut();
 		}
 
-		$('html, body').animate({scrollTop: $().offset().top}, 1000);
+		$('html, body').animate({scrollTop: $(this).offset().bottom}, 1000);
 	});
 });

--- a/assets/sass/components/_card.scss
+++ b/assets/sass/components/_card.scss
@@ -35,4 +35,6 @@
 	}
 
 	&__hidden { display: none; }
+
+	&__buffer { height: 0; }
 }

--- a/assets/sass/pages/_list.scss
+++ b/assets/sass/pages/_list.scss
@@ -5,7 +5,7 @@
 		border: 4px solid $chinder-cultured;
 		padding: 0 3rem 3rem 3rem;
 		display: flex;
-		justify-content: space-between;
+		justify-content: space-around;
 		flex-flow: row wrap;
 		margin-top: -5.5rem;
 		z-index: -1;

--- a/layouts/_default/alle-artikel.html
+++ b/layouts/_default/alle-artikel.html
@@ -23,6 +23,7 @@
 					</div>
 				</a>
 			{{ end }}
+			<div class="card card__buffer"></div>
 		</div>
 		<div class="btn__container">
 			<a href="#" class="btn btn--primary" id="loadMore">Mehr Artikel</a>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -33,6 +33,7 @@
 					</div>
 				</a>
 			{{ end }}
+			<div class="card card__buffer"></div>
 		</div>
 		<div class="btn__container">
 			<a href="#" class="btn btn--primary" id="loadMore">Mehr Artikel</a>


### PR DESCRIPTION
- Added an article buffer that forces a row with less than three articles to align on the left-hand side of the container:

<img width="1405" alt="CleanShot 2020-09-18 at 08 19 47@2x" src="https://user-images.githubusercontent.com/16960228/93563241-c937cd00-f987-11ea-9790-8cad860d4383.png">

- Fixed jQuery console error for top of undefined

- Justified marker spacing to around instead of between; it still looks a little weird when a category only has two tags, but now there is much less white space between the markers in this scenario.