### PR TITLE
Article updates

### DIFF
--- a/assets/sass/base/_typography.scss
+++ b/assets/sass/base/_typography.scss
@@ -91,7 +91,7 @@ body {
 .fremdwort {
 	&:link,
 	&:visited {
-		color: $chinder-verdigris;
+		color: $chinder-orange;
 	}
 }
 
@@ -105,7 +105,7 @@ body {
 			text-decoration: none;
 		}
 
-		&:hover { color: $chinder-verdigris; }
+		&:hover { color: $chinder-orange; }
 	}
 
 	&__word { font-size: $font-heading; }
@@ -380,12 +380,12 @@ body {
 /* ----- SINGLE TEMPLATE ------ */
 .single {
 
-	&__image {
-
-		&-src { color: $social-base; }
+	&__date-author {
+		color: $social-base;
+		font-size: 1.3rem;
 	}
 
-	&__date-author {
+	&__image-src {
 		color: $social-base;
 		font-size: 1.3rem;
 	}
@@ -399,7 +399,9 @@ body {
 
 		p { text-align: justify; }
 
-		a { color: $color-black; }
+		a { color: $chinder-verdigris; }
+
+		.image__src { @extend .single__image-src; }
 	}
 
 	&__comments {

--- a/assets/sass/base/_typography.scss
+++ b/assets/sass/base/_typography.scss
@@ -1,6 +1,6 @@
 body {
 	font-family: 'Lato', sans-serif;
-	font-size: $font-small;
+	font-size: $font-default;
 	font-weight: 100;
 	line-height: 1.6;
 }
@@ -82,10 +82,7 @@ body {
 		&-date {
 			font-weight: 300;
 
-			&--highlight {
-				font-size: $font-default;
-				font-weight: 300;
-			}
+			&--highlight { font-weight: 300; }
 		}
 	}
 }
@@ -178,10 +175,7 @@ body {
 		color: $chinder-orange;
 	}
 
-	&__title {
-		font-size: $font-default;
-		color: $chinder-verdigris;
-	}
+	&__title { color: $chinder-verdigris; }
 }
 
 
@@ -192,7 +186,6 @@ body {
 /* ----- NAVBAR ------ */
 .nav {
 	font-family: $font-patrick, $font-fallback;
-	font-size: $font-default;
 
 	&__notice {
 
@@ -287,10 +280,7 @@ body {
 		}
 	}
 
-	&--nav {
-		color: $social-base;
-		font-size: $font-default;
-	}
+	&--nav { color: $social-base; }
 
 	&--footer { color: $chinder-platinum; }
 
@@ -407,10 +397,7 @@ body {
 			color: $chinder-orange;
 		}
 
-		p {
-			font-size: 1.8rem;
-			text-align: justify;
-		}
+		p { text-align: justify; }
 
 		a { color: $color-black; }
 	}

--- a/assets/sass/pages/_single.scss
+++ b/assets/sass/pages/_single.scss
@@ -36,7 +36,7 @@
 
 		h2 { margin-bottom: 1.5rem; }
 
-		p { margin-bottom: $margin-s; }
+		p, li { margin-bottom: $margin-s; }
 	}
 
 	&__comments {

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,7 +4,7 @@
 			<figure class="single__image">
 				<img src="{{ .Site.Params.cloudinary_url }}/c_scale,q_auto:good,w_800/{{ .Params.hero_img }}" alt="{{ .Params.img_description }}" class="single__image-img">
 				<figcaption class="single__image-caption">
-					{{ partial "svgs/triangle_svg.html" (dict "fill" "#000" "width" 15 "height" 15) }}
+					{{ partial "svgs/triangle_svg.html" (dict "fill" "#6C685D" "width" 15 "height" 15) }}
 					<a href="{{ .Params.img_src }}" target="_blank" class="single__image-src">
 						<div class="single__image-photographer">@{{ .Params.img_photographer }}</div>
 					</a>

--- a/layouts/shortcodes/definition.html
+++ b/layouts/shortcodes/definition.html
@@ -1,7 +1,7 @@
-<div class="definition" id="definition-{{ .Get `wort`}}">
+<div class="definition" id="definition-{{ .Get `wort` | lower }}">
 	<div class="definition__content">
-		<a href="#fremdwort-{{ .Get `wort`}}" class="definition__close">&times;</a>
-		<h2 class="definition__word">{{ .Get "wort" }}</h2>
+		<a href="#fremdwort-{{ .Get `wort` | lower }}" class="definition__close">&times;</a>
+		<h2 class="definition__word">{{ .Get "wort" | humanize }}</h2>
 		<p class="definition__definition">{{ .Get "def" }}</p>
 	</div>
 </div>

--- a/layouts/shortcodes/fremdwort.html
+++ b/layouts/shortcodes/fremdwort.html
@@ -1,1 +1,1 @@
-<a href="#definition-{{ .Get `wort`}}" class="fremdwort" id="fremdwort-{{ .Get `wort`}}">{{ .Get "wort" }}</a>
+<a href="#definition-{{ .Get `wort` | lower }}" class="fremdwort" id="fremdwort-{{ .Get `wort` | lower }}">{{ .Get "wort" }}</a>

--- a/layouts/shortcodes/image.html
+++ b/layouts/shortcodes/image.html
@@ -1,7 +1,7 @@
 <figure class="image">
 	<img src="{{ .Site.Params.cloudinary_url }}/c_scale,q_auto:good,w_500/{{ .Get `img` }}" alt="{{ .Get `desc` }}" class="image__img">
 	<figcaption class="image__caption">
-		{{ partial "svgs/triangle_svg.html" (dict "fill" "#000" "width" 15 "height" 15) }}
+		{{ partial "svgs/triangle_svg.html" (dict "fill" "#6C685D" "width" 15 "height" 15) }}
 		<a href="{{ .Get `src` }}" target="_blank" class="image__src">
 			<div class="image__photographer">@{{ .Get "photographer" }}</div>
 		</a>


### PR DESCRIPTION
Made the following updates to article text:
- Default text size is now `1.8rem/18px` across the board;
- Article fremdwort definition link colour is now orange, while all other links in article text is chinder blue (verdigris). link text for image sources remains the same; and
- Forced lowercasing of fremdwort and fremdwort definition ids, and the uppercasing of fremdwort definition title. So, no matter how you enter the word in the fremdwort and fremdwort definition shortcodes, the word will be forced into lowercase so that the linking will still work, and the definition title will always be capitalised.