### PR TITLE
Creative Commons attribution option

### DIFF
--- a/.forestry/snippets/image.snippet
+++ b/.forestry/snippets/image.snippet
@@ -1,1 +1,1 @@
-{{< image img="Enter file with ext. here" desc="Enter photo description here" src="Enter photo src here" photographer="Enter name here" >}}
+{{< image img="Enter file with ext. here" desc="Enter photo description here" photographer="Enter name here" src="Enter photo src here" cc_licence="Enter CC licence type here" cc_src="Enter CC licence link here" >}}

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -8,6 +8,8 @@ hero_img:
 img_description:
 img_photographer:
 img_src:
+cc_licence:
+cc_src:
 kategorien: []
 markierungen: []
 fdw: false

--- a/assets/sass/base/_typography.scss
+++ b/assets/sass/base/_typography.scss
@@ -385,9 +385,12 @@ body {
 		font-size: 1.3rem;
 	}
 
-	&__image-src {
+	&__image-src,
+	&__caption-buffer,
+	&__cc-src {
 		color: $social-base;
 		font-size: 1.3rem;
+		text-decoration: none;
 	}
 
 	&__content {
@@ -401,7 +404,9 @@ body {
 
 		a { color: $chinder-verdigris; }
 
-		.image__src { @extend .single__image-src; }
+		.image__src,
+		.single__caption-buffer,
+		.single__cc-src { @extend .single__image-src; }
 
 		.arbeitsmaterial__link { color: $color-black; }
 	}

--- a/assets/sass/pages/_single.scss
+++ b/assets/sass/pages/_single.scss
@@ -20,6 +20,8 @@
 		&-src { margin-left: .5rem; }
 	}
 
+	&__caption-buffer { margin-left: .5rem; }
+
 	&__taxonomies { display: flex; }
 
 	&__date-author {

--- a/content/radioaktiver-abfall-vergessen-ist-gefahrlich.md
+++ b/content/radioaktiver-abfall-vergessen-ist-gefahrlich.md
@@ -6,9 +6,11 @@ description = ""
 draft = true
 fdw = false
 hero_img = "/v1600417843/radioaktivitaet_eckr9r.jpg"
-img_description = ""
+img_description = "Geiger counter measuring radiation levels in the area of Chernobyl"
 img_photographer = "Jorge Fernández Salas"
 img_src = "https://unsplash.com/@jorgefdezsalas"
+cc_licence = ""
+cc_src = ""
 kategorien = ["Welt", "Natur/Umwelt"]
 markierungen = ["Energie"]
 paid = false
@@ -21,11 +23,10 @@ _Radioaktives Material ist sehr schädlich – und das viele tausend Jahre lang.
 Im Dezember 2019 wurde das Atomkraftwerk Mühleberg (in der Nähe von Bern) abgestellt. Das Gebäude wird nun abgebaut. Das meiste Material kann man entsorgen wie bei einem Haus, das abgerissen wird. Aber in einem Atomkraftwerk entsteht auch ein besonders gefährlicher Abfall:  
 radioaktives Material.
 
-<a title="BKW FMB Energie AG / CC BY-SA ([https://creativecommons.org/licenses/by-sa/3.0](https://creativecommons.org/licenses/by-sa/3.0 "https://creativecommons.org/licenses/by-sa/3.0"))" href="![](https://commons.wikimedia.org/wiki/File:KernkraftwerkM%C3%BChleberg.jpg)"><img width="512" alt="KernkraftwerkMühleberg" src="![](https://upload.wikimedia.org/wikipedia/commons/8/87/KernkraftwerkM%C3%BChleberg.jpg)"></a>
+{{< image img="KernkraftwerkMühleberg_g4nvtn.jpg" desc="Via Wikimedia Commons" photographer="BKW FMB Energie AG" src="https://commons.wikimedia.org/wiki/File:KernkraftwerkM%C3%BChleberg.jpg" cc_licence="CC BY-SA" cc_src="https://creativecommons.org/licenses/by-sa/3.0/deed.de" >}}
 
 ## Müllentsorgung für die Zukunft
 
-  
 Radioaktives Material ist wegen seiner Strahlung sehr gefährlich für Menschen und Tiere. Die Strahlung verändert die Körperzellen. Dadurch entstehen Krankheiten. Das radioaktive Material muss deshalb in einer gut gesicherten Deponie gelagert werden – und zwar lange, bis die Strahlung aufhört. Das dauert viele tausend Jahre. Diese lange Zeit ist es ein Problem: Es ist nämlich möglich, dass die Menschen in tausend oder zweitausend Jahren vergessen haben, was radioaktives Material ist. Sie kommen vielleicht auf die Idee, die Deponie wieder auszugraben, weil sie neugierig sind auf den Inhalt. Das klingt auf den ersten Blick seltsam, aber viele Sachen werden vergessen. Die Römer und Kelten lebten vor 2‘000 Jahren in der Schweiz. Von ihnen ist nicht viel übrig geblieben: verfallene Ruinen, Teller, Töpfe, alte Werkzeuge. Wir kennen ihr Leben fast nur durch Ausgrabungen.
 
 Forscherinnen und Forscher machen sich deshalb schon heute Gedanken, wie man die Menschen in der Zukunft warnen kann. Sie glauben, dass einfache Zeichnungen und Symbole auf Schildern am besten funktionieren. Die Schilder werden dann bei den Deponien aufgestellt, in denen das radioaktive Material vergraben wird. Die Schilder müssen sehr stabil sein, damit sie lange halten. Buchstaben und Texte sind keine gute Idee. Denn vielleicht verstehen die Menschen in tausend Jahren unsere Sprache nicht mehr.

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -5,9 +5,15 @@
 				<img src="{{ .Site.Params.cloudinary_url }}/c_scale,q_auto:good,w_800/{{ .Params.hero_img }}" alt="{{ .Params.img_description }}" class="single__image-img">
 				<figcaption class="single__image-caption">
 					{{ partial "svgs/triangle_svg.html" (dict "fill" "#6C685D" "width" 15 "height" 15) }}
-					<a href="{{ .Params.img_src }}" target="_blank" class="single__image-src">
-						<div class="single__image-photographer">@{{ .Params.img_photographer }}</div>
+					<a href="{{ .Params.img_src }}" title="{{ .Params.img_description }}" target="_blank" class="single__image-src">
+						<div class="single__image-photographer">{{ .Params.img_photographer }}</div>
 					</a>
+					{{ if .Params.cc_licence }}
+						<div class="single__caption-buffer">/</div>
+						<a href="{{ .Params.cc_src }}" target="_blank" class="single__cc-src">
+							<div class="single__cc-licence">{{ .Params.cc_licence }}</div>
+						</a>
+					{{ end }}
 				</figcaption>
 			</figure>
 			<div class="single__taxonomies">

--- a/layouts/shortcodes/image.html
+++ b/layouts/shortcodes/image.html
@@ -2,8 +2,14 @@
 	<img src="{{ .Site.Params.cloudinary_url }}/c_scale,q_auto:good,w_500/{{ .Get `img` }}" alt="{{ .Get `desc` }}" class="image__img">
 	<figcaption class="image__caption">
 		{{ partial "svgs/triangle_svg.html" (dict "fill" "#6C685D" "width" 15 "height" 15) }}
-		<a href="{{ .Get `src` }}" target="_blank" class="image__src">
-			<div class="image__photographer">@{{ .Get "photographer" }}</div>
+		<a href="{{ .Get `src` }}" title="{{ .Get `desc` }}" target="_blank" class="image__src">
+			<div class="image__photographer">{{ .Get "photographer" }}</div>
 		</a>
+		{{ if .Params.cc_licence }}
+			<div class="single__caption-buffer">/</div>
+			<a href="{{ .Get `cc_src` }}" target="_blank" class="single__cc-src">
+				<div class="single__cc-licence">{{ .Get "cc_licence" }}</div>
+			</a>
+		{{ end }}
 	</figcaption>
 </figure>


### PR DESCRIPTION
Because some photos used on the website fall under Creative Commons, I added variables to both the article archtypes and image shortcode, that will allow the publisher to add Creative Commons attribution should any image need it.

![CleanShot 2020-09-18 at 12 09 36@2x](https://user-images.githubusercontent.com/16960228/93585985-ed0b0b00-f9a7-11ea-849a-0e7c66bdfbb3.png)

Also, Image author links now have a title attribute. When you hove over the link, the title will pop-up as a tool tip. This is more of a need for Creative Commons attribution requirements, but it works well with or without a CC attribution.

![CleanShot 2020-09-18 at 12 13 45](https://user-images.githubusercontent.com/16960228/93586455-a10c9600-f9a8-11ea-8464-57dd905d95bf.gif)
 