### PR TITLE
Create generic centered container shortcode

### DIFF
--- a/.forestry/snippets/arbeitsmaterial.snippet
+++ b/.forestry/snippets/arbeitsmaterial.snippet
@@ -1,3 +1,3 @@
-{{< arbeitsmaterial-container >}}
+{{< container-center >}}
 	{{< arbeitsmaterial file="add file name without extension" >}}
-{{< /arbeitsmaterial-container >}}
+{{< /container-center >}}

--- a/assets/sass/components/_arbeitsmaterial.scss
+++ b/assets/sass/components/_arbeitsmaterial.scss
@@ -1,10 +1,4 @@
 .arbeitsmaterial {
-	margin-bottom: $margin-s;
-
-	&__container {
-		display: flex;
-		justify-content: space-around;
-	}
 
 	&__link {
 		display: flex;

--- a/assets/sass/components/_container_center.scss
+++ b/assets/sass/components/_container_center.scss
@@ -1,0 +1,5 @@
+.container__center {
+	display: flex;
+	justify-content: space-around;
+	margin-bottom: $margin-s;
+}

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -9,6 +9,7 @@
 @import "components/breadcrumb";
 @import "components/btn";
 @import "components/card";
+@import "components/container_center";
 @import "components/definition";
 @import "components/fdw_svg";
 @import "components/image";

--- a/assets/sass/pages/_single.scss
+++ b/assets/sass/pages/_single.scss
@@ -39,6 +39,11 @@
 		h2 { margin-bottom: 1.5rem; }
 
 		p, li { margin-bottom: $margin-s; }
+
+		&-iframe {
+			display: flex;
+			align-self: center;
+		}
 	}
 
 	&__comments {

--- a/content/bigfoot-der-menschenaffe-aus-nordamerika.md
+++ b/content/bigfoot-der-menschenaffe-aus-nordamerika.md
@@ -48,6 +48,6 @@ Viele der älteren Sichtungen oder Aufnahmen geschahen zufällig. Seit einigen J
 
 ## Arbeitsmaterial
 
-{{< arbeitsmaterial-container >}}
+{{< container-center >}}
 {{< arbeitsmaterial file="bigfoot-arbeitsmaterial_wikmrx" >}}
-{{< /arbeitsmaterial-container >}}
+{{< /container-center >}}

--- a/content/billie-eilish-die-angesagteste-pop-sangerin-von-heute.md
+++ b/content/billie-eilish-die-angesagteste-pop-sangerin-von-heute.md
@@ -23,6 +23,6 @@ Ihr erstes Album landete in der Hitparade der USA sofort auf Platz 1. 12 ihrer 1
 
 ## Arbeitsmaterial
 
-{{< arbeitsmaterial-container >}}
+{{< container-center >}}
 {{< arbeitsmaterial file="billie-ellish-arbeitmaterial_btdqpc" >}}
-{{< /arbeitsmaterial-container >}}
+{{< /container-center >}}

--- a/content/die-jagdsaison-warum-5560-hirsche-erschossen-werden.md
+++ b/content/die-jagdsaison-warum-5560-hirsche-erschossen-werden.md
@@ -46,6 +46,6 @@ Jagd in Graubünden:
 
 ## Arbeitsmaterial
 
-{{< arbeitsmaterial-container >}}
+{{< container-center >}}
 {{< arbeitsmaterial file="jagsaison-arbeitsmaterial_td4zbb" >}}
-{{< /arbeitsmaterial-container >}}
+{{< /container-center >}}

--- a/content/keine-corona-infizierten-in-nordkorea.md
+++ b/content/keine-corona-infizierten-in-nordkorea.md
@@ -50,6 +50,6 @@ Abbildungen 1 und 2: [https://www.dw.com/de/coronavirus-ist-nordkorea-virenfrei/
 
 ## Arbeitsmaterial
 
-{{< arbeitsmaterial-container >}}
+{{< container-center >}}
 	{{< arbeitsmaterial file="nordkorea-und-corona-arbeitsmaterial_ofbj21" >}}
-{{< /arbeitsmaterial-container >}}
+{{< /container-center >}}

--- a/content/kreislaufwirtschaft.md
+++ b/content/kreislaufwirtschaft.md
@@ -49,8 +49,8 @@ Am 17. September 2020 fand die Konferenz zur Kreislaufwirtschaft statt. Diese Ko
 
 ## Arbeitsmaterial
 
-{{< arbeitsmaterial-container >}}
+{{< container-center >}}
 {{< arbeitsmaterial file="Kreislaufwirtschaft-arbeitsmaterial_fgferx" >}}
-{{< /arbeitsmaterial-container >}}
+{{< /container-center >}}
 
 ## 

--- a/content/nessie-das-ungeheuer-von-loch-ness.md
+++ b/content/nessie-das-ungeheuer-von-loch-ness.md
@@ -48,6 +48,6 @@ So hat sich im Laufe der Jahrhunderte das Bild der Sagengestalt gewandelt. Aus d
 
 ## Arbeitsmaterial
 
-{{< arbeitsmaterial-container >}} {{< arbeitsmaterial file="loch-ness-monster-arbeitsmaterial_c3qd3p" >}} {{< /arbeitsmaterial-container >}}
+{{< container-center >}} {{< arbeitsmaterial file="loch-ness-monster-arbeitsmaterial_c3qd3p" >}} {{< /container-center >}}
 
 ## 

--- a/content/seit-fast-70-jahren-fliegt-sie-durch-die-lufte.md
+++ b/content/seit-fast-70-jahren-fliegt-sie-durch-die-lufte.md
@@ -45,4 +45,4 @@ Rega Homepage: [https://www.rega.ch/](https://www.rega.ch/ "https://www.rega.ch/
 
 ## Arbeitsmaterial
 
-{{< arbeitsmaterial-container >}} {{< arbeitsmaterial file="rega-arbeitsmaterial_g35awb" >}} {{< /arbeitsmaterial-container >}}
+{{< container-center >}} {{< arbeitsmaterial file="rega-arbeitsmaterial_g35awb" >}} {{< /container-center >}}

--- a/content/sie-sie-sie-auch-me-too.md
+++ b/content/sie-sie-sie-auch-me-too.md
@@ -25,7 +25,9 @@ Diese zwei Worte sind die berühmtesten Worte auf sozialen Plattformen wie z.B T
 
 {{< definition wort="sexuell-genötigt" def="Sexuelle Nötigung bedeutet, dass sexuelle Handlungen gegen den Willen des Opfers gemacht werden. Vergewaltigung ist auch eine Art von sexueller Nötigung, bei der das Opfer nicht «nur» zu sexuellen Handlungen, sondern auch zu Sex gezwungen wird." >}}
 
-{{< tweet 919659438700670976 >}}
+{{< container-center >}}
+	{{< tweet 919659438700670976 >}}
+{{< /container-center >}}
 
 ## #metoo erobert die Welt
 

--- a/content/warum-singen-vogel.md
+++ b/content/warum-singen-vogel.md
@@ -44,8 +44,8 @@ Der Gesang hat also mehrere Funktionen: Als Markierung des Reviers, als Lockruf 
 
 ## Arbeitsmaterial
 
-{{< arbeitsmaterial-container >}}
+{{< container-center >}}
 {{< arbeitsmaterial file="warum-singen-voegel-arbeitsmaterial_b1bv4h" >}}
-{{< /arbeitsmaterial-container >}}
+{{< /container-center >}}
 
 ## 

--- a/content/wer-kann-lesen-und-schreiben.md
+++ b/content/wer-kann-lesen-und-schreiben.md
@@ -41,4 +41,4 @@ Am 8. September ist der Welttag der Alphabetisierung. An diesem Tag will die {{<
 
 ## Arbeitsmaterial
 
-{{< arbeitsmaterial-container >}} {{< arbeitsmaterial file="welt-alphabetisierungs-tag-arbeitsmateral_bsb4mx" >}} {{< /arbeitsmaterial-container >}}
+{{< container-center >}} {{< arbeitsmaterial file="welt-alphabetisierungs-tag-arbeitsmateral_bsb4mx" >}} {{< /container-center >}}

--- a/content/yeti-der-schneemensch-aus-dem-himalaya.md
+++ b/content/yeti-der-schneemensch-aus-dem-himalaya.md
@@ -48,8 +48,8 @@ Die bekannteste Yeti-Sichtung stammt von Reinhold Messner. Der berühmte österr
 
 ## Arbeitsmaterial
 
-{{< arbeitsmaterial-container >}}
+{{< container-center >}}
 {{< arbeitsmaterial file="yeti-arbeitsmaterial_yj1uzu" >}}
-{{< /arbeitsmaterial-container >}}
+{{< /container-center >}}
 
 ## 

--- a/layouts/shortcodes/arbeitsmaterial-container.html
+++ b/layouts/shortcodes/arbeitsmaterial-container.html
@@ -1,1 +1,0 @@
-<div class="arbeitsmaterial__container">{{ .Inner }}</div>

--- a/layouts/shortcodes/container-center.html
+++ b/layouts/shortcodes/container-center.html
@@ -1,0 +1,1 @@
+<div class="container__center">{{ .Inner }}</div>


### PR DESCRIPTION
With the inclusion of a tweet iframe and, potentially, future iframes, I renamed the arbeitsmaterial-container to container-center. Now this container shortcode can be used to wrap any element that requires centering within an article.