### PR TITLE
Marker fixes

### DIFF
--- a/assets/sass/base/_typography.scss
+++ b/assets/sass/base/_typography.scss
@@ -160,6 +160,8 @@ body {
 
 	&:hover,
 	&:active { color: $color-white; }
+
+	&--article { font-size: 1.3rem; }
 }
 
 /* ----- PROFILE ------ */

--- a/assets/sass/components/_marker.scss
+++ b/assets/sass/components/_marker.scss
@@ -19,5 +19,6 @@
 	&--list {
 		padding: 1rem;
 		margin-top: 3rem;
+		margin-right: 1.5rem;
 	}
 }

--- a/assets/sass/components/_marker.scss
+++ b/assets/sass/components/_marker.scss
@@ -3,7 +3,6 @@
 	&:link,
 	&:visited {
 		background-color: $chinder-platinum;
-
 		border-radius: .5rem;
 	}
 


### PR DESCRIPTION
For this PR:
- Added `margin-right` to list markers so that they are no longer bunching up. Still can't fix the noticeable whitespace gaps with categories that have so few tags; this is the side affect of using flexbox.
- Decreased `font-size` for markers listed in the article to avoid them competing with the article heading.