### PR TITLE
Fix cart item count cut-off on ipad

### DIFF
--- a/assets/sass/components/_snipcart.scss
+++ b/assets/sass/components/_snipcart.scss
@@ -16,13 +16,19 @@
 		cursor: pointer;
 	}
 
+	&.snipcart-checkout {
+		display: flex;
+		flex-direction: column-reverse;
+		align-items: center;
+	}
+
 	&.snipcart-items-count {
 		background-color: #a21017;
 		padding: .5rem 1rem;
 		border-radius: 10rem;
-		margin-top: -1.8rem;
-		margin-left: -2.9rem;
 	}
+
+	&.snipcart-customer-signin { align-self: flex-end; }
 }
 
 .cart:active,


### PR DESCRIPTION
Arranged the cart and item number count as a flex column instead of using negative margins.