### PR TITLE
Card Responsive

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -5,14 +5,14 @@ $(document).ready(function() {
 		$('html, body').animate({scrollTop: $('.js-section-comments').offset().top}, 1000);
 	});
 
-	if($(".card__hidden:hidden").length < 8) {$("#loadMore").hide();}
+	if($(".card__hidden:hidden").length < 6) {$("#loadMore").hide();}
 
-	$(".card__hidden").slice(0, 8).show();
+	$(".card__hidden").slice(0, 6).show();
 
 	$("#loadMore").on('click', function (e) {
 		e.preventDefault();
 
-		$(".card__hidden:hidden").slice(0, 4).slideDown();
+		$(".card__hidden:hidden").slice(0, 3).slideDown();
 		if($(".card__hidden:hidden").length == 0) {
 			$("#loadMore").fadeOut();
 		}

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -5,7 +5,7 @@ $(document).ready(function() {
 		$('html, body').animate({scrollTop: $('.js-section-comments').offset().top}, 1000);
 	});
 
-	if($(".card__hidden:hidden").length < 4) {$("#loadMore").hide();}
+	if($(".card__hidden:hidden").length < 8) {$("#loadMore").hide();}
 
 	$(".card__hidden").slice(0, 8).show();
 

--- a/assets/sass/components/_card.scss
+++ b/assets/sass/components/_card.scss
@@ -1,16 +1,32 @@
 .card {
-	height: 38rem;
-	width: 25rem;
+	height: 40rem;
+	width: 30rem;
 	margin-top: 3rem;
+	position: relative;
+	z-index: 0;
 
-	&__photo { height: 16.7rem; }
+	@include respond(tab-port-xl) {
+		height: 38rem;
+		width: 25rem;
+	}
+
+	&__img {
+		height: 20rem;
+		position: relative;
+		display: block;
+		z-index: -1;
+
+		@include respond(tab-port-xl) { height: 16.7rem; }
+	}
 
 	&__content {
-		height: 21.3rem;
+		height: 20rem;
 		padding: 1.5rem;
 		display: flex;
 		flex-direction: column;
 		justify-content: space-between;
+
+		@include respond(tab-port-xl) { height: 21.3rem; }
 	}
 
 	&--grey { background-color: $chinder-cultured; }
@@ -22,7 +38,7 @@
 	&:hover {
 		background-color: $color-black;
 
-		.card__photo { box-shadow: inset 0 0 0 1rem $color-black; }
+		.card__img-container { box-shadow: inset 0 0 0 1rem $color-black; }
 	}
 
 	&__list { @include container-main; }

--- a/layouts/_default/alle-artikel.html
+++ b/layouts/_default/alle-artikel.html
@@ -16,7 +16,15 @@
 			{{ $artikel := where (where .Site.Pages ".Params.artikel" true) ".Params.fdw" false }}
 			{{ range $artikel.ByTitle }}
 				<a href="{{.RelPermalink}}" class="card card--grey card__hidden">
-					<div style="background:url({{ .Site.Params.cloudinary_url }}/c_scale,h_170,w_300,q_auto:good/{{ .Params.hero_img }})" class="card__photo"></div>
+					<div class="card__img-container">
+						<img srcset="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }},
+							{{ .Site.Params.cloudinary_url }}/f_auto,h_180,w_270,q_auto:good/{{ .Params.hero_img }} 1100w,
+							{{ .Site.Params.cloudinary_url }}/f_auto,h_167,w_250,q_auto:good/{{ .Params.hero_img }} 900w"
+							src="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }}"
+							alt="{{ .Params.img_description }}"
+							class="card__img"
+						/>
+					</div>
 					<div class="card__content">
 						<h3 class="card__content-title">{{ .Title }}</h3>
 						<div class="card__content-date">{{ .Date.Format .Site.Params.DateForm }}</div>

--- a/layouts/_default/fokus-der-woche.html
+++ b/layouts/_default/fokus-der-woche.html
@@ -22,7 +22,15 @@
 			{{ $fdwArtikel := where .Site.Pages ".Params.fdw" true }}
 			{{ range $fdwArtikel.ByDate.Reverse }}
 				<a href="{{.RelPermalink}}" class="card card--grey card__hidden">
-					<div style="background:url({{ .Site.Params.cloudinary_url }}/c_scale,h_170,w_300,q_auto:good/{{ .Params.hero_img }})" class="card__photo"></div>
+					<div class="card__img-container">
+						<img srcset="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }},
+							{{ .Site.Params.cloudinary_url }}/f_auto,h_180,w_270,q_auto:good/{{ .Params.hero_img }} 1100w,
+							{{ .Site.Params.cloudinary_url }}/f_auto,h_167,w_250,q_auto:good/{{ .Params.hero_img }} 900w"
+							src="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }}"
+							alt="{{ .Params.img_description }}"
+							class="card__img"
+						/>
+					</div>
 					<div class="card__content">
 						<h3 class="card__content-title">{{ .Title }}</h3>
 						<div class="card__content-date">{{ .Date.Format .Site.Params.DateForm }}</div>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -26,7 +26,15 @@
 		<div class="card__container">
 			{{ range .Pages.ByTitle }}
 				<a href="{{.RelPermalink}}" class="card card--grey card__hidden">
-					<div style="background:url({{ .Site.Params.cloudinary_url }}/c_scale,h_170,w_300,q_auto:good/{{ .Params.hero_img }})" class="card__photo"></div>
+					<div class="card__img-container">
+						<img srcset="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }},
+							{{ .Site.Params.cloudinary_url }}/f_auto,h_180,w_270,q_auto:good/{{ .Params.hero_img }} 1100w,
+							{{ .Site.Params.cloudinary_url }}/f_auto,h_167,w_250,q_auto:good/{{ .Params.hero_img }} 900w"
+							src="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }}"
+							alt="{{ .Params.img_description }}"
+							class="card__img"
+						/>
+					</div>
 					<div class="card__content">
 						<h3 class="card__content-title">{{ .Title }}</h3>
 						<div class="card__content-date">{{ .Date.Format .Site.Params.DateForm }}</div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,7 +9,15 @@
 			<div class="card__container">
 				{{ range first 3 (index .Site.Taxonomies.markierungen "covid-19") }}
 					<a href="{{.RelPermalink}}" class="card card--white">
-						<div style="background:url({{ .Site.Params.cloudinary_url }}/c_scale,w_250,q_auto:good/{{ .Params.hero_img }})" class="card__photo"></div>
+						<div class="card__img-container">
+							<img srcset="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }},
+								{{ .Site.Params.cloudinary_url }}/f_auto,h_180,w_270,q_auto:good/{{ .Params.hero_img }} 1100w,
+								{{ .Site.Params.cloudinary_url }}/f_auto,h_167,w_250,q_auto:good/{{ .Params.hero_img }} 900w"
+								src="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }}"
+								alt="{{ .Params.img_description }}"
+								class="card__img"
+							/>
+						</div>
 						<div class="card__content">
 							<h3 class="card__content-title">{{ .Title }}</h3>
 							<div class="card__content-date">{{ .Date.Format .Site.Params.DateForm }}</div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -37,7 +37,15 @@
 			{{ $artikel := where (where .Site.Pages ".Params.artikel" true) ".Params.fdw" false }}
 			{{ range first 3 $artikel.ByDate.Reverse }}
 				<a href="{{.RelPermalink}}" class="card card--grey">
-					<div style="background:url({{ .Site.Params.cloudinary_url }}/c_scale,h_170,w_300,q_auto:good/{{ .Params.hero_img }})" class="card__photo"></div>
+					<div class="card__img-container">
+						<img srcset="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }},
+							{{ .Site.Params.cloudinary_url }}/f_auto,h_180,w_270,q_auto:good/{{ .Params.hero_img }} 1100w,
+							{{ .Site.Params.cloudinary_url }}/f_auto,h_167,w_250,q_auto:good/{{ .Params.hero_img }} 900w"
+							src="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }}"
+							alt="{{ .Params.img_description }}"
+							class="card__img"
+						/>
+					</div>
 					<div class="card__content">
 						<h3 class="card__content-title">{{ .Title }}</h3>
 						<div class="card__content-date">{{ .Date.Format .Site.Params.DateForm }}</div>
@@ -58,7 +66,15 @@
 			{{ $fdwArtikel := where .Site.Pages ".Params.fdw" true }}
 			{{ range first 1 $fdwArtikel.ByDate.Reverse }}
 				<a href="{{.RelPermalink}}" class="card card--white">
-					<div style="background:url({{ .Site.Params.cloudinary_url }}/c_scale,h_170,w_300,q_auto:good/{{ .Params.hero_img }})" class="card__photo"></div>
+					<div class="card__img-container">
+						<img srcset="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }},
+							{{ .Site.Params.cloudinary_url }}/f_auto,h_180,w_270,q_auto:good/{{ .Params.hero_img }} 1100w,
+							{{ .Site.Params.cloudinary_url }}/f_auto,h_167,w_250,q_auto:good/{{ .Params.hero_img }} 900w"
+							src="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }}"
+							alt="{{ .Params.img_description }}"
+							class="card__img"
+						/>
+					</div>
 					<div class="card__content">
 						<h3 class="card__content-title">{{ .Title }}</h3>
 						<div class="card__content-date">{{ .Date.Format .Site.Params.DateForm }}</div>


### PR DESCRIPTION
- Adjusted height and width of article card at 900px to resolve gross flex-wrap styling on tablets;
- Converted card images from a `div` with an inline background image to an actual `img` tag;
- Added `srcset` attributes to card image tag for responsive functionality; and
- Updated all ctas and article lists to accommodate new card style.