### PR TITLE
Arbeitsmaterial snippet fix

### DIFF
--- a/assets/sass/components/_container_center.scss
+++ b/assets/sass/components/_container_center.scss
@@ -1,5 +1,1 @@
-.container__center {
-	display: flex;
-	justify-content: space-around;
-	margin-bottom: $margin-s;
-}
+.container__center {margin-bottom: $margin-s; }

--- a/content/9-11-ein-datum-das-die-welt-veranderte.md
+++ b/content/9-11-ein-datum-das-die-welt-veranderte.md
@@ -37,6 +37,4 @@ Warum sagt man 9/11 (nine-eleven)? Im US-Englisch nimmt man den Monat vor dem Ta
 
 {{< teiler >}}
 
-## Arbeitsmaterial
-
 {{< container-center >}} {{< arbeitsmaterial file="nine-eleven-arbeitsmaterial_upqqbx" >}} {{< /container-center >}}

--- a/content/bigfoot-der-menschenaffe-aus-nordamerika.md
+++ b/content/bigfoot-der-menschenaffe-aus-nordamerika.md
@@ -46,8 +46,6 @@ Viele der älteren Sichtungen oder Aufnahmen geschahen zufällig. Seit einigen J
 
 {{< teiler >}}
 
-## Arbeitsmaterial
-
 {{< container-center >}}
 {{< arbeitsmaterial file="bigfoot-arbeitsmaterial_wikmrx" >}}
 {{< /container-center >}}

--- a/content/billie-eilish-die-angesagteste-pop-sangerin-von-heute.md
+++ b/content/billie-eilish-die-angesagteste-pop-sangerin-von-heute.md
@@ -21,8 +21,6 @@ Ihr erstes Album landete in der Hitparade der USA sofort auf Platz 1. 12 ihrer 1
 
 {{< teiler >}}
 
-## Arbeitsmaterial
-
 {{< container-center >}}
 {{< arbeitsmaterial file="billie-ellish-arbeitmaterial_btdqpc" >}}
 {{< /container-center >}}

--- a/content/boris-johnson-und-sein-brexit.md
+++ b/content/boris-johnson-und-sein-brexit.md
@@ -23,10 +23,6 @@ England gehört zur EU dazu. Nun hat ein bisschen mehr als die Hälfte des Volke
 
 {{< teiler >}}
 
-## Arbeitsmaterial
-
 {{< container-center >}}
 {{< arbeitsmaterial file="brexit_fhv0qz" >}}
 {{< /container-center >}}
-
-## 

--- a/content/corona-macht-schule.md
+++ b/content/corona-macht-schule.md
@@ -25,7 +25,6 @@ Warum? Es geht darum, unser Gesundheitssystem zu entlasten, in dem sich die Mens
 
 * Schulen und Lehrpersonen müssen nun dafür sorgen, dass Schulkinder digital, per Post oder per Abholtermin mit Unterrichtsmaterial versorgt werden. Das heisst, ihr kriegt wohl bald Hausaufgaben und Aufträge, die ihr zu Hause erledigen müsst. Die Schule ist zu, aber die Arbeit geht nicht aus. Das Nötigste muss erledigt werden.
 
-
 * Eure Eltern übernehmen den Unterricht nicht, müssen aber dafür sorgen, dass ihr eure Hausaufträge erledigt.
 
 {{< image img="corona-macht-schule_hwqt6j.jpg" desc="Empty classroom" src="https://unsplash.com/@flpschi" photographer="Feliphe Schiarolli" >}}

--- a/content/das-kurdische-volk.md
+++ b/content/das-kurdische-volk.md
@@ -37,10 +37,6 @@ Wenn ihr mehr zu den Kurden erfahren wollt, könnt ihr einen unserer bereits pub
 
 {{< teiler >}}
 
-## Arbeitsmaterial
-
 {{< container-center >}}
 {{< arbeitsmaterial file="kurdische-volk-arbeitsmaterial_op1rav" >}}
 {{< /container-center >}}
-
-## 

--- a/content/der-grosse-krieg-ist-nicht-entstanden.was-ist-sonst-geschehen-im-iran.md
+++ b/content/der-grosse-krieg-ist-nicht-entstanden.was-ist-sonst-geschehen-im-iran.md
@@ -39,8 +39,6 @@ Seit Januar dieses Jahres hat der Iran auch mit dem Corona-Virus zu kämpfen. Ne
 
 {{< teiler >}}
 
-## Arbeitsmaterial
-
 {{< container-center >}}
 {{< arbeitsmaterial file="iran-arbeitsmaterial_djnhsy" >}}
 {{< /container-center >}}

--- a/content/die-arbeiterpartei-kurdistan-pkk.md
+++ b/content/die-arbeiterpartei-kurdistan-pkk.md
@@ -35,8 +35,6 @@ Wir haben in mehreren Artikeln über die Konflikte im nahen Osten berichtet. Die
 
 {{< teiler >}}
 
-## Arbeitsmaterial
-
 {{< container-center >}}
 {{< arbeitsmaterial file="arbeiterpartei-kurdistan-arbeitsmaterial_vq9unb" >}}
 {{< /container-center >}}

--- a/content/die-jagdsaison-warum-5560-hirsche-erschossen-werden.md
+++ b/content/die-jagdsaison-warum-5560-hirsche-erschossen-werden.md
@@ -44,8 +44,6 @@ Jagd in Graubünden:
 
 {{< teiler >}}
 
-## Arbeitsmaterial
-
 {{< container-center >}}
 {{< arbeitsmaterial file="jagsaison-arbeitsmaterial_td4zbb" >}}
 {{< /container-center >}}

--- a/content/die-kurden-in-syrien.md
+++ b/content/die-kurden-in-syrien.md
@@ -39,8 +39,6 @@ Rund 150’000 Frauen, Männer und Kinder sind wegen des türkischen Angriffs be
 
 {{< teiler >}}
 
-## Arbeitsmaterial
-
 {{< container-center >}}
 {{< arbeitsmaterial file="kurden-in-syrien-arbeitsmaterial_qiuzsc" >}}
 {{< /container-center >}}

--- a/content/fokus-der-woche-kommentar-der-redaktion-wir-konnen-nicht-atmen.md
+++ b/content/fokus-der-woche-kommentar-der-redaktion-wir-konnen-nicht-atmen.md
@@ -40,9 +40,3 @@ Wir können die Welt zwar leider nicht so einfach ändern. Wir können fast nur 
 ## Nun bist du an der Reihe
 
 Wie wirkt der Fokus der Woche auf dich? Was denkst du zum Thema? Was denken dein Freunde, deine Familie? Welche Gefühle kommen auf, welche Diskussionen entstehen? Sprich darüber - und melde dich doch auch bei uns. Entweder mit einem Kommentar in der Kommentarspalte, auf Facebook oder durch unser [Kontaktformular](https://chinderzytig-v1.netlify.app/kontakt/). Wir freuen uns auf Rückmeldungen.
-
-{{< teiler >}}
-
-{{< container-center >}}
-{{< arbeitsmaterial file="arbeiterpartei-kurdistan-arbeitsmaterial_vq9unb" >}}
-{{< /container-center >}}

--- a/content/keine-corona-infizierten-in-nordkorea.md
+++ b/content/keine-corona-infizierten-in-nordkorea.md
@@ -48,8 +48,6 @@ Abbildungen 1 und 2: [https://www.dw.com/de/coronavirus-ist-nordkorea-virenfrei/
 
 {{< teiler >}}
 
-## Arbeitsmaterial
-
 {{< container-center >}}
 	{{< arbeitsmaterial file="nordkorea-und-corona-arbeitsmaterial_ofbj21" >}}
 {{< /container-center >}}

--- a/content/kreislaufwirtschaft.md
+++ b/content/kreislaufwirtschaft.md
@@ -47,10 +47,8 @@ Am 17. September 2020 fand die Konferenz zur Kreislaufwirtschaft statt. Diese Ko
 
 {{< teiler >}}
 
-## Arbeitsmaterial
-
 {{< container-center >}}
 {{< arbeitsmaterial file="Kreislaufwirtschaft-arbeitsmaterial_fgferx" >}}
 {{< /container-center >}}
 
-## 
+##

--- a/content/kreislaufwirtschaft.md
+++ b/content/kreislaufwirtschaft.md
@@ -50,5 +50,3 @@ Am 17. September 2020 fand die Konferenz zur Kreislaufwirtschaft statt. Diese Ko
 {{< container-center >}}
 {{< arbeitsmaterial file="Kreislaufwirtschaft-arbeitsmaterial_fgferx" >}}
 {{< /container-center >}}
-
-##

--- a/content/nach-dem-brexit-folgte-der-megxit.md
+++ b/content/nach-dem-brexit-folgte-der-megxit.md
@@ -25,7 +25,7 @@ Der Januar 2020 war ein turbulenter Monat für Grossbritannien. Am 31. Januar 20
 
 Seit dem 1. April ist es nun soweit: Meghan Markle und Prinz Harry sind keine Royals mehr. Sie leben in Amerika und versuchen dort auch einen Beruf zu finden. Eben ein ganz normales Leben zu führen. Trotz des Austritts wird Harry von der Thronfolge nicht ausgeschlossen und muss spätestens dann wieder die Aufgaben eines Mitglieds der Königsfamilie wahrnehmen.
 
-## #Megxit​
+##Megxit​
 
 Seit der Austritt bekannt ist, hören wir immer wieder in den Medien von Megxit oder #Megxit. Doch es ist nicht klar, wann der Name entstand. Bereits als die Hochzeit von Harry und Meghan bekannt wurde, verwendeten einige Medien diesen Begriff. Es gab und gibt viele Kritiker von Meghan Markle. Sie soll England umgehend wieder verlassen und auch Prinz Harry und sie schade der Königsfamilie, dies könnten wir immer wieder lesen und hören. Der Begriff kombiniert sich aus Meghan und exit – was so viel heisst wie Austritt. Stark wurde der Begriff jedoch erst, als der Austritt aus dem Königshaus bekannt wurde.
 

--- a/content/nessie-das-ungeheuer-von-loch-ness.md
+++ b/content/nessie-das-ungeheuer-von-loch-ness.md
@@ -46,8 +46,4 @@ So hat sich im Laufe der Jahrhunderte das Bild der Sagengestalt gewandelt. Aus d
 
 {{< teiler >}}
 
-## Arbeitsmaterial
-
 {{< container-center >}} {{< arbeitsmaterial file="loch-ness-monster-arbeitsmaterial_c3qd3p" >}} {{< /container-center >}}
-
-## 

--- a/content/palastinensischer-terrorismus.md
+++ b/content/palastinensischer-terrorismus.md
@@ -43,8 +43,6 @@ Riegler, Thomas (2018): «Das «Spinnennetz» des internationalen Terrorismus- D
 
 {{< teiler >}}
 
-## Arbeitsmaterial
-
 {{< container-center >}}
 {{< arbeitsmaterial file="palaestinensischer-terrorismus-arbeitsmaterial_xz6iwc" >}}
 {{< /container-center >}}

--- a/content/seit-fast-70-jahren-fliegt-sie-durch-die-lufte.md
+++ b/content/seit-fast-70-jahren-fliegt-sie-durch-die-lufte.md
@@ -29,7 +29,7 @@ Sobald ein Alarm beim Team eingeht, macht sich der Pilot gemeinsam mit einem Arz
 
 Bei schlechtem Wetter oder wenn das Gelände sehr steil ist, kann der Pilot oft nicht bei seinem Patienten landen. Dann kommt eine sogenannte Rettungswinde zum Einsatz: Das ist ein starkes Seil, an dem der Arzt zur verletzten Person hinuntergelassen werden kann. Der Arzt kümmert sich um den Verletzten und macht ihn dann an der Winde fest. Zusammen werden die beiden wieder zum Helikopter heraufgezogen. Anschliessend fliegt der Rega-Pilot den Patienten in ein Spital.
 
-So sieht die Arbeit mit der Rettungswinde aus: [https://www.rega.ch/fileadmin/seiteninhalt/PDFs/Illustrationen_Centerfolds/Illustration_Rettungswinde_de.pdf](https://www.rega.ch/fileadmin/seiteninhalt/PDFs/Illustrationen_Centerfolds/Illustration_Rettungswinde_de.pdf "https://www.rega.ch/fileadmin/seiteninhalt/PDFs/Illustrationen_Centerfolds/Illustration_Rettungswinde_de.pdf")
+So sieht die Arbeit mit der Rettungswinde aus: [Illustration_Rettungswinde_de.pdf](https://www.rega.ch/fileadmin/seiteninhalt/PDFs/Illustrationen_Centerfolds/Illustration_Rettungswinde_de.pdf "https://www.rega.ch/fileadmin/seiteninhalt/PDFs/Illustrationen_Centerfolds/Illustration_Rettungswinde_de.pdf")
 
 {{< image img="rega-2_wfozso.jpg" desc="Rega plane flying over the Alps" src="https://unsplash.com/@mrcalvert" photographer="Seb Mooze" >}}
 
@@ -44,7 +44,5 @@ Heute besteht die Flotte der Rega aus 18 Rettungshelikoptern und 3 Ambulanzjets.
 Rega Homepage: [https://www.rega.ch/](https://www.rega.ch/ "https://www.rega.ch/")
 
 {{< teiler >}}
-
-## Arbeitsmaterial
 
 {{< container-center >}} {{< arbeitsmaterial file="rega-arbeitsmaterial_g35awb" >}} {{< /container-center >}}

--- a/content/warum-singen-vogel.md
+++ b/content/warum-singen-vogel.md
@@ -42,10 +42,8 @@ Der Gesang hat also mehrere Funktionen: Als Markierung des Reviers, als Lockruf 
 
 {{< teiler >}}
 
-## Arbeitsmaterial
-
 {{< container-center >}}
 {{< arbeitsmaterial file="warum-singen-voegel-arbeitsmaterial_b1bv4h" >}}
 {{< /container-center >}}
 
-## 
+##

--- a/content/wer-kann-lesen-und-schreiben.md
+++ b/content/wer-kann-lesen-und-schreiben.md
@@ -39,6 +39,4 @@ Am 8. September ist der Welttag der Alphabetisierung. An diesem Tag will die {{<
 
 {{< teiler >}}
 
-## Arbeitsmaterial
-
 {{< container-center >}} {{< arbeitsmaterial file="welt-alphabetisierungs-tag-arbeitsmateral_bsb4mx" >}} {{< /container-center >}}

--- a/content/yeti-der-schneemensch-aus-dem-himalaya.md
+++ b/content/yeti-der-schneemensch-aus-dem-himalaya.md
@@ -46,10 +46,6 @@ Die bekannteste Yeti-Sichtung stammt von Reinhold Messner. Der berühmte österr
 
 {{< teiler >}}
 
-## Arbeitsmaterial
-
 {{< container-center >}}
 {{< arbeitsmaterial file="yeti-arbeitsmaterial_yj1uzu" >}}
 {{< /container-center >}}
-
-## 


### PR DESCRIPTION
Initial update to the arbeitsmaterial shortcode and snippet in PR #60 still had a styling issue to deal with, so this PR:
- Resolves that issue by removing the justified center on the entire container; and
- Removal of all the duplicate `h2` headers for the arbeitsmaterial that were already there after porting over the content. 