### PR TITLE
Definition title fix

### DIFF
--- a/layouts/shortcodes/definition.html
+++ b/layouts/shortcodes/definition.html
@@ -1,7 +1,7 @@
 <div class="definition" id="definition-{{ .Get `id` | urlize }}">
 	<div class="definition__content">
 		<a href="#fremdwort-{{ .Get `id` | urlize }}" class="definition__close">&times;</a>
-		<h2 class="definition__word">{{ .Get "wort" }}</h2>
+		<h3 class="definition__word">{{ .Get "wort" }}</h3>
 		<p class="definition__definition">{{ .Get "def" }}</p>
 	</div>
 </div>


### PR DESCRIPTION
When updating the article sub-heading styles, I forgot to update the definition title to an `h3` element, thus loosing it's intended styling.

before:
<img width="1327" alt="CleanShot 2020-10-04 at 11 03 28@2x" src="https://user-images.githubusercontent.com/16960228/95011578-f2b45200-0631-11eb-98d0-fe9412d8fdbe.png">

after:
<img width="1358" alt="CleanShot 2020-10-04 at 11 08 46@2x" src="https://user-images.githubusercontent.com/16960228/95011590-03fd5e80-0632-11eb-8873-1ebd64088ba7.png">
