### PR TITLE
Space multiple arbeitsmaterial horizontally

### DIFF
--- a/assets/sass/components/_arbeitsmaterial.scss
+++ b/assets/sass/components/_arbeitsmaterial.scss
@@ -1,5 +1,10 @@
 .arbeitsmaterial {
 
+	&__container {
+		display: flex;
+		justify-content: space-around;
+	}
+
 	&__heading {
 		font-size: $font-bigger;
 		font-family: $font-patrick, $font-fallback;

--- a/assets/sass/components/_container_center.scss
+++ b/assets/sass/components/_container_center.scss
@@ -1,1 +1,1 @@
-.container__center {margin-bottom: $margin-s; }
+.container__center { margin-bottom: $margin-s; }

--- a/content/das-perfekte-auto.md
+++ b/content/das-perfekte-auto.md
@@ -37,9 +37,6 @@ Fazit: Die Idee der Elektroautos sind gut, doch braucht es bessere und umweltfre
 
 {{< container-center >}}
 {{< arbeitsmaterial file="das-perfekte-auto-arbeitsmaterial_mecdrd" >}}
-
 {{< arbeitsmaterial file= "das-perfekte-auto-arbeitsmaterial-2_vkd5xo" >}}
-
 {{< arbeitsmaterial file= "das-perfekte-auto-arbeitsmaterial-3_iskcfc" >}}
-
 {{< /container-center >}}

--- a/layouts/shortcodes/arbeitsmaterial.html
+++ b/layouts/shortcodes/arbeitsmaterial.html
@@ -1,7 +1,4 @@
-<h3 class="arbeitsmaterial__heading">Arbeitsmaterial</h3>
-<div class="arbeitsmaterial">
-	<a href="{{ .Site.Params.cloudinary_url }}/{{ .Get `file`}}.pdf" target="_blank" class="arbeitsmaterial__link">
-		<img src="{{ .Site.Params.cloudinary_url }}/bo_1px_solid_rgb:000000,c_scale,h_200,q_auto:best/{{ .Get `file`}}.png" alt="Arbeitsmaterial cover" class="arbeitsmaterial__file">
-		<div class="arbeitsmaterial__file-name">PDF</div>
-	</a>
-</div>
+<a href="{{ .Site.Params.cloudinary_url }}/{{ .Get `file`}}.pdf" target="_blank" class="arbeitsmaterial__link">
+	<img src="{{ .Site.Params.cloudinary_url }}/bo_1px_solid_rgb:000000,c_scale,h_200,q_auto:best/{{ .Get `file`}}.png" alt="Arbeitsmaterial cover" class="arbeitsmaterial__file">
+	<div class="arbeitsmaterial__file-name">PDF</div>
+</a>

--- a/layouts/shortcodes/container-center.html
+++ b/layouts/shortcodes/container-center.html
@@ -1,1 +1,6 @@
-<div class="container__center">{{ .Inner }}</div>
+<div class="container__center">
+	<h3 class="arbeitsmaterial__heading">Arbeitsmaterial</h3>
+	<div class="arbeitsmaterial__container">
+		{{ .Inner }}
+	</div>
+</div>


### PR DESCRIPTION
Added the flex container to the container-center shortcode that is built into the arbeitsmaterial snippet. This fixes the vertical alignment of articles with more than one arbeitsmaterial PDF.

**Before:**

![CleanShot 2020-10-06 at 17 17 43@2x](https://user-images.githubusercontent.com/16960228/95221577-de21b680-07f7-11eb-974b-4c6e042331bf.png)

**After:**

<img width="1200" alt="CleanShot 2020-10-06 at 17 12 08@2x" src="https://user-images.githubusercontent.com/16960228/95221643-f265b380-07f7-11eb-816a-2035d438e49b.png">
