### PR TITLE
Temorarily disable Snipcart Store

### DIFF
--- a/assets/sass/components/_btn.scss
+++ b/assets/sass/components/_btn.scss
@@ -70,6 +70,13 @@
 		&:active { .arrow { fill: $color-white; } }
 	}
 
+	&--disabled {
+		border: 2px solid rgba(16, 16, 16, 0.3);
+
+		&:hover,
+		&:active { color: rgba(16, 16, 16, 0.3); }
+	}
+
 	&__container {
 		text-align: center;
 		margin-top: $margin-m;

--- a/assets/sass/components/_snipcart.scss
+++ b/assets/sass/components/_snipcart.scss
@@ -2,27 +2,36 @@
 
 	&-modal__container { z-index: 3000; }
 
-	&__cart:active,
-	&__cart:hover,
-	&__account:active,
-	&__account:hover { fill: #6C685D; }
+	// &__cart:active,
+	// &__cart:hover,
+	// &__account:active,
+	// &__account:hover { fill: #6C685D; }
 }
 
 .snipcart-overwrite {
 	display: flex;
+	border: none;
+	background-color: #fff;
+	cursor: pointer;
 
-	&.snipcart-checkout,
-	&.snipcart-customer-signin {
-		border: none;
-		background-color: #fff;
-		cursor: pointer;
-	}
+	// &.snipcart-checkout,
+	// &.snipcart-customer-signin {
+	// 	border: none;
+	// 	background-color: #fff;
+	// 	cursor: pointer;
+	// }
 
-	&.snipcart-checkout {
+	&.snipcart--cart {
 		display: flex;
 		flex-direction: column-reverse;
 		align-items: center;
 	}
+
+	// &.snipcart-checkout {
+	// 	display: flex;
+	// 	flex-direction: column-reverse;
+	// 	align-items: center;
+	// }
 
 	&.snipcart-items-count {
 		background-color: #a21017;
@@ -30,8 +39,7 @@
 		border-radius: 10rem;
 	}
 
+	&.snipcart--signin { align-self: flex-end; }
+
 	&.snipcart-customer-signin { align-self: flex-end; }
 }
-
-.cart:active,
-.cart:hover { fill: #6C685D; }

--- a/layouts/_default/abonnemente.html
+++ b/layouts/_default/abonnemente.html
@@ -44,7 +44,8 @@
 						{{ end }}
 					</div>
 					<img src="{{ $.Site.Params.cloudinary_url }}/c_scale,h_250,q_auto:good/logos/{{ .img }}" alt="{{ .alt }}" class="abonnemente__img">
-					{{ range .btn }}
+					<button class="btn btn--disabled" disabled>Blied Dran</button>
+					<!-- {{ range .btn }}
 						<button class="btn btn--{{ .class }} abonnemente__cta snipcart-add-item"
 							data-item-id="{{ .id }}"
 							data-item-price="{{ .price }}"
@@ -56,7 +57,7 @@
 							data-item-custom1-options="{{ .custom_options }}">
 							Auswählen
 						</button>
-					{{ end }}
+					{{ end }} -->
 				</div>
 			{{ end }}
 		</div>

--- a/layouts/_default/abonnemente.html
+++ b/layouts/_default/abonnemente.html
@@ -44,7 +44,7 @@
 						{{ end }}
 					</div>
 					<img src="{{ $.Site.Params.cloudinary_url }}/c_scale,h_250,q_auto:good/logos/{{ .img }}" alt="{{ .alt }}" class="abonnemente__img">
-					<button class="btn btn--disabled" disabled>Blied Dran</button>
+					<button class="btn btn--disabled" disabled>Demnächst verfügbar</button>
 					<!-- {{ range .btn }}
 						<button class="btn btn--{{ .class }} abonnemente__cta snipcart-add-item"
 							data-item-id="{{ .id }}"

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -17,11 +17,11 @@
 			</div>
 		</a>
 		<div class="nav__ecommerce">
-			<button class="snipcart-overwrite snipcart-checkout">
+			<button class="snipcart-overwrite snipcart--cart">
 				{{ partial "svgs/cart_svg.html" (dict "fill" "#4C4C4C" "width" 35 "height" 35) }}
 				<span class="snipcart-overwrite snipcart-items-count">0</span>
 			</button>
-			<button class="snipcart-overwrite snipcart-customer-signin">
+			<button class="snipcart-overwrite snipcart--signin">
 				{{ partial "svgs/account_svg.html" (dict "fill" "#4C4C4C" "width" 35 "height" 35) }}
 			</button>
 		</div>

--- a/layouts/partials/support_us.html
+++ b/layouts/partials/support_us.html
@@ -21,7 +21,7 @@
 				Auch kleine Spenden können eine grosse Wirkung erzielen.
 			</p>
 			<div class="support__options-btns">
-				<button class="btn btn--disabled" disabled>Blied dran</button>
+				<button class="btn btn--disabled" disabled>Demnächst verfügbar</button>
 				<!-- {{ range .Site.Data.partials.support.donation }}
 					<button class="btn btn--secondary support__options-btn snipcart-add-item"
 						data-item-id="{{ .id }}"

--- a/layouts/partials/support_us.html
+++ b/layouts/partials/support_us.html
@@ -21,7 +21,8 @@
 				Auch kleine Spenden können eine grosse Wirkung erzielen.
 			</p>
 			<div class="support__options-btns">
-				{{ range .Site.Data.partials.support.donation }}
+				<button class="btn btn--disabled" disabled>Blied dran</button>
+				<!-- {{ range .Site.Data.partials.support.donation }}
 					<button class="btn btn--secondary support__options-btn snipcart-add-item"
 						data-item-id="{{ .id }}"
 						data-item-price="{{ .price }}"
@@ -31,7 +32,7 @@
 						data-item-name="{{ .label }} Spende an Chinderzytig">
 						{{ .label }}
 					</button>
-				{{ end }}
+				{{ end }} -->
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
With DNS propagation happening within the next 24 hours, and still unable to accept payments, I have disable the buttons that:
- add products to the store (ie. donations and subscriptions);
- accesses the cart directly (navigation bar); and
- accesses the Snipcart accounts creation/login page.

Support us component:

<img width="1176" alt="CleanShot 2020-10-09 at 13 12 08@2x" src="https://user-images.githubusercontent.com/16960228/95576705-30015100-0a31-11eb-99c6-0c36d99c19a3.png">

Abonnemente page:

<img width="1087" alt="CleanShot 2020-10-09 at 13 12 25@2x" src="https://user-images.githubusercontent.com/16960228/95576728-38f22280-0a31-11eb-8bb9-e2387e61f6fe.png">

