### PR TITLE
Add Datenschutz to website

### DIFF
--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -27,6 +27,7 @@
 @import "layout/navbar";
 
 @import "pages/abonnemente";
+@import "pages/datenschutz";
 @import "pages/fokus_der_woche";
 @import "pages/index";
 @import "pages/kontakt";

--- a/assets/sass/pages/_datenschutz.scss
+++ b/assets/sass/pages/_datenschutz.scss
@@ -1,0 +1,6 @@
+.datenschutz {
+
+	&__container { @include container-main; }
+}
+
+.iub_content.legal_pp { font-family: 'Lato', sans-serif; }

--- a/content/datenschutz.md
+++ b/content/datenschutz.md
@@ -1,0 +1,5 @@
+---
+title: "Datenschutz"
+layout: datenschutz
+artikel: false
+---

--- a/data/partials/footer.yaml
+++ b/data/partials/footer.yaml
@@ -9,9 +9,9 @@ main:
     link: "/verein"
   - label: Kontakt
     link: "/kontakt"
-  - label: Seitenverzeichnis
-    link: "#"
   - label: Datenschutz
+    link: "/datenschutz"
+  - label: Seitenverzeichnis
     link: "#"
   - label: Admin
     link: "/admin"

--- a/layouts/_default/datenschutz.html
+++ b/layouts/_default/datenschutz.html
@@ -1,0 +1,5 @@
+{{ define "main" }}
+	<div class="datenschutz__container">
+		<a href="https://www.iubenda.com/privacy-policy/62519371" class="iubenda-white no-brand iubenda-embed iub-body-embed datenschutz__iubenda" title="Privacy Policy">Privacy Policy</a><script type="text/javascript">(function (w,d) {var loader = function () {var s = d.createElement("script"), tag = d.getElementsByTagName("script")[0]; s.src="https://cdn.iubenda.com/iubenda.js"; tag.parentNode.insertBefore(s,tag);}; if(w.addEventListener){w.addEventListener("load", loader, false);}else if(w.attachEvent){w.attachEvent("onload", loader);}else{w.onload = loader;}})(window, document);</script>
+	</div>
+{{ end }}

--- a/layouts/_default/kontakt.html
+++ b/layouts/_default/kontakt.html
@@ -44,7 +44,7 @@
 					<label for="datenschutz">
 						Ich bin einverstanden, dass meine Personendaten im Kontext dieses
 						Formulars verarbeitet werden. Mehr Informationen finden Sie unter
-						<a href="#" class="kontakt__datenschutz">chinderzytig.ch/datenschutz</a>.
+						<a href="/datenschutz" class="kontakt__datenschutz">chinderzytig.ch/datenschutz</a>.
 					</label>
 				</div>
 				<div class="kontakt__hidden">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -15,6 +15,11 @@
 	<meta name="msapplication-TileColor" content="#00aba9">
 	<meta name="theme-color" content="#ffffff">
 	<title>{{ if .Title }}{{ .Title }}{{ else }}{{ .Site.Title }}{{ end }} | Chinderzytig</title>
+	<script type="text/javascript">
+		var _iub = _iub || [];
+		_iub.csConfiguration = {"gdprAppliesGlobally":false,"consentOnContinuedBrowsing":false,"lang":"de","siteId":2026849,"cookiePolicyId":62519371, "banner":{ "brandBackgroundColor":"none","brandTextColor":"black","acceptButtonDisplay":true,"customizeButtonDisplay":true,"acceptButtonColor":"#30afaa","acceptButtonCaptionColor":"white","customizeButtonColor":"#ec633f","customizeButtonCaptionColor":"#ffffff","rejectButtonColor":"#0073CE","rejectButtonCaptionColor":"white","position":"float-bottom-right","backgroundOverlay":true,"textColor":"black","backgroundColor":"#ffffff" }};
+	</script>
+	<script type="text/javascript" src="//cdn.iubenda.com/cs/iubenda_cs.js" charset="UTF-8" async></script>
 	<link href="https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&family=Patrick+Hand&display=swap" rel="stylesheet">
 	<link rel="preconnect" href="https://app.snipcart.com">
 	<link rel="preconnect" href="https://cdn.snipcart.com">


### PR DESCRIPTION
Created the Chinderzytig Datenschutz and added it to its respective page on the website. Also created a cookie consent pop-up to let users know what we use under the hood. This isn't top of the line but it's better than most websites. We will see how this goes, but if we run into an issue down the road, we may need to beef up these practices.

![CleanShot 2020-10-09 at 18 16 20](https://user-images.githubusercontent.com/16960228/95607174-a6b34400-0a5b-11eb-8644-31637ce14341.gif)
