### PR TITLE
Add alias for 26.04.1986 - Tschernobyl article

### DIFF
--- a/content/26.04.1986-tschernobyl.md
+++ b/content/26.04.1986-tschernobyl.md
@@ -15,6 +15,10 @@ markierungen = ["Ukraine", "Energie"]
 paid = false
 slug = "tschernobyl"
 title = "26.04.1986 - Tschernobyl"
+aliases = [
+    "/kopie-von-weltmalariatag",
+    "/tschernobyl"
+]
 
 +++
 _Im Jahr 1986 hielt die ganze Erde den Atem an. In der damaligen Sowjetunion war ein katastrophales Ereignis geschehen, das leider immer noch aktuell ist._


### PR DESCRIPTION
This Tschernobyl article was originally pointing to `www.chinderzytig.ch/kopie-von-weltmalariatag`, which is obviously a mistake when creating this article. Now that the article points to `www.chinderzytig.ch/tschernobyl`, I created an alias in the frontmatter so that if someone goes to the original link, they will be redirected to the new one.