### PR TITLE
Osano Cookie banner

### DIFF
--- a/assets/sass/components/_osano.scss
+++ b/assets/sass/components/_osano.scss
@@ -1,0 +1,7 @@
+.osano-cm-widget {
+
+	svg path {
+			fill: $chinder-orange;
+			stroke: $chinder-verdigris !important;
+		}
+}

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -16,6 +16,7 @@
 @import "components/marker";
 @import "components/menu";
 @import "components/newsletter";
+@import "components/osano";
 @import "components/profile";
 @import "components/snipcart";
 @import "components/social_svgs";


### PR DESCRIPTION
This PR is strictly for updating the colours for the Osano widget:
![CleanShot 2020-10-14 at 15 45 19@2x](https://user-images.githubusercontent.com/16960228/95997755-63c6e700-0e34-11eb-9c03-72aef97e456c.png)

However, this is notification that the Cookie banner is now active.

Users in Switzerland:
<img width="1680" alt="CleanShot 2020-10-14 at 15 38 51@2x" src="https://user-images.githubusercontent.com/16960228/95997898-91139500-0e34-11eb-9a57-3b1ca406082f.png">

Users in EU countries that require GDPR compliance (in this example Germany):
<img width="1680" alt="CleanShot 2020-10-14 at 15 37 32@2x" src="https://user-images.githubusercontent.com/16960228/95998005-b7393500-0e34-11eb-8cf9-ee8da6e3818d.png">

The banner will automatically translate into most languages in the EU. If the banner shows up in language you didn't expect, you must check the language settings in the operating system of your computer.