### PR TITLE
Arbeitsmaterial page

### DIFF
--- a/.forestry/snippets/arbeitsmaterial.snippet
+++ b/.forestry/snippets/arbeitsmaterial.snippet
@@ -1,5 +1,5 @@
 {{< teiler >}}
 
 {{< arbeitsmaterial-group >}}
-	{{< arbeitsmaterial file="add file name without extension" >}}
+	{{< arbeitsmaterial >}}
 {{< /arbeitsmaterial-group >}}

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -12,6 +12,7 @@ cc_licence:
 cc_src:
 kategorien: []
 markierungen: []
+arbeitsmaterial:
 fdw: false
 paid: false
 artikel: true

--- a/assets/sass/base/_typography.scss
+++ b/assets/sass/base/_typography.scss
@@ -8,9 +8,6 @@ body {
 // -----------------------------------------------
 // COMPONENTS
 // -----------------------------------------------
-/* ----- ARBEITSMATERIAL (SHORTCODE) ------ */
-.arbeitsmaterial { &__link { text-decoration: none; } }
-
 /* ----- CARD ------ */
 .card {
 

--- a/assets/sass/components/_arbeitsmaterial-shortcode.scss
+++ b/assets/sass/components/_arbeitsmaterial-shortcode.scss
@@ -1,4 +1,4 @@
-.arbeitsmaterial {
+.arbeitsmaterial-sc {
 
 	&-group { margin-bottom: $margin-s; }
 
@@ -15,10 +15,14 @@
 	}
 
 	&__link {
+		text-decoration: none;
 		display: flex;
 		flex-direction: column;
 		align-items: center;
 	}
 
-	&__file-name { margin-top: .5rem; }
+	&__file-name {
+		color: $color-black;
+		margin-top: .5rem;
+	}
 }

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -28,6 +28,7 @@
 @import "layout/navbar";
 
 @import "pages/abonnemente";
+@import "pages/arbeitsmaterial";
 @import "pages/datenschutz";
 @import "pages/fokus_der_woche";
 @import "pages/index";

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -4,7 +4,7 @@
 @import "base/base";
 @import "base/typography";
 
-@import "components/arbeitsmaterial";
+@import "components/arbeitsmaterial-shortcode";
 @import "components/article_svgs";
 @import "components/breadcrumb";
 @import "components/btn";

--- a/assets/sass/pages/_arbeitsmaterial.scss
+++ b/assets/sass/pages/_arbeitsmaterial.scss
@@ -29,6 +29,10 @@
 			flex-direction: column;
 		}
 
-		&-btn { &:first-child { margin-bottom: 3rem; } }
+		&-btn {
+			text-align: center;
+
+			&:first-child { margin-bottom: 3rem; }
+		}
 	}
 }

--- a/assets/sass/pages/_arbeitsmaterial.scss
+++ b/assets/sass/pages/_arbeitsmaterial.scss
@@ -9,6 +9,7 @@
 		width: 30rem;
 		display: flex;
 		flex-direction: column;
+		margin-top: 3rem;
 		padding: 2rem;
 
 		&-upper { margin-bottom: 2rem; }

--- a/assets/sass/pages/_arbeitsmaterial.scss
+++ b/assets/sass/pages/_arbeitsmaterial.scss
@@ -12,12 +12,16 @@
 		margin-top: 3rem;
 		padding: 2rem;
 
+		@include respond(tab-port-xl) { width: 25rem; }
+
 		&-upper { margin-bottom: 2rem; }
 
 		&-lower {
 			display: flex;
 			justify-content: space-between;
 			align-items: center;
+
+			@include respond(tab-port-xl) { flex-direction: column; }
 		}
 
 		&-title {
@@ -28,12 +32,22 @@
 		&-btns {
 			display: flex;
 			flex-direction: column;
+
+			@include respond(tab-port-xl) { width: 100% }
 		}
 
 		&-btn {
 			text-align: center;
 
 			&:first-child { margin-bottom: 3rem; }
+
+			@include respond(tab-port-xl) {
+				&:first-child { margin-bottom: 0; }
+
+				margin-top: 1.5rem;
+			}
 		}
 	}
 }
+
+.card__hidden { display: none; }

--- a/assets/sass/pages/_arbeitsmaterial.scss
+++ b/assets/sass/pages/_arbeitsmaterial.scss
@@ -1,0 +1,34 @@
+.arbeitsmaterial {
+
+	&__container {
+		@include container-main;
+	}
+
+	&__card {
+		background-color: $chinder-cultured;
+		width: 30rem;
+		display: flex;
+		flex-direction: column;
+		padding: 2rem;
+
+		&-upper { margin-bottom: 2rem; }
+
+		&-lower {
+			display: flex;
+			justify-content: space-between;
+			align-items: center;
+		}
+
+		&-title {
+			font-family: $font-patrick, $font-fallback;
+			text-align: center;
+		}
+
+		&-btns {
+			display: flex;
+			flex-direction: column;
+		}
+
+		&-btn { &:first-child { margin-bottom: 3rem; } }
+	}
+}

--- a/content/9-11-ein-datum-das-die-welt-veranderte.md
+++ b/content/9-11-ein-datum-das-die-welt-veranderte.md
@@ -15,6 +15,7 @@ markierungen = ["USA", "Kriege/Konflikte"]
 paid = false
 slug = "nine-eleven"
 title = "9/11 - ein Datum, das die Welt veränderte"
+arbeitsmaterial = "nine-eleven-arbeitsmaterial_upqqbx"
 
 +++
 _Es gibt Ereignisse, die für die Menschen unvergesslich bleiben. Die Bilder bleiben in den Köpfen hängen. Man erinnert sich genau, was man in diesem Moment gerade gemacht hat und wo man war. Wenn man mit Menschen über 30 spricht, oder speziell mit Menschen aus den USA, dann kann jede*r seine Geschichte des 11. Septembers erzählen. 9/11 – ein Datum, das sich in die Köpfe hinein gebrannt hat._
@@ -37,4 +38,4 @@ Warum sagt man 9/11 (nine-eleven)? Im US-Englisch nimmt man den Monat vor dem Ta
 
 {{< teiler >}}
 
-{{< arbeitsmaterial-group >}} {{< arbeitsmaterial file="nine-eleven-arbeitsmaterial_upqqbx" >}} {{< /arbeitsmaterial-group >}}
+{{< arbeitsmaterial-group >}} {{< arbeitsmaterial >}} {{< /arbeitsmaterial-group >}}

--- a/content/arbeitsmaterial.md
+++ b/content/arbeitsmaterial.md
@@ -1,0 +1,5 @@
+---
+title: Arbeitsmaterial
+layout: arbeitsmaterial
+artikel: false
+---

--- a/content/bigfoot-der-menschenaffe-aus-nordamerika.md
+++ b/content/bigfoot-der-menschenaffe-aus-nordamerika.md
@@ -15,6 +15,7 @@ markierungen = ["Tierwelt"]
 paid = false
 slug = "sagenhafte-tiere-teil-3-bigfoot"
 title = "Bigfoot: Der Menschenaffe aus Nordamerika"
+arbeitsmaterial = "bigfoot-arbeitsmaterial_wikmrx"
 
 +++
 ### Serie: Sagenhafte Tiere
@@ -49,5 +50,5 @@ Viele der älteren Sichtungen oder Aufnahmen geschahen zufällig. Seit einigen J
 {{< teiler >}}
 
 {{< arbeitsmaterial-group >}}
-{{< arbeitsmaterial file="bigfoot-arbeitsmaterial_wikmrx" >}}
+{{< arbeitsmaterial >}}
 {{< /arbeitsmaterial-group >}}

--- a/content/billie-eilish-die-angesagteste-pop-sangerin-von-heute.md
+++ b/content/billie-eilish-die-angesagteste-pop-sangerin-von-heute.md
@@ -13,6 +13,7 @@ markierungen = ["USA", "Musik"]
 paid = false
 slug = "billieeilish"
 title = "Billie Eilish – die angesagteste Pop-Sängerin von heute"
+arbeitsmaterial = "billie-ellish-arbeitmaterial_btdqpc"
 
 +++
 _Viele Teenager lieben die Musik und den Stil von Billie Eilish. Das 17jährige Mädchen füllt Konzertsäle und gilt als die angesagteste Sängerin für die heutige Jugend. Was unterscheidet sie von anderen? Was macht sie so erfolgreich?_
@@ -22,5 +23,5 @@ Ihr erstes Album landete in der Hitparade der USA sofort auf Platz 1. 12 ihrer 1
 {{< teiler >}}
 
 {{< arbeitsmaterial-group >}}
-{{< arbeitsmaterial file="billie-ellish-arbeitmaterial_btdqpc" >}}
+{{< arbeitsmaterial >}}
 {{< /arbeitsmaterial-group >}}

--- a/content/bin-ich-schon-was-ist-schon-like-oder-nicht-like.md
+++ b/content/bin-ich-schon-was-ist-schon-like-oder-nicht-like.md
@@ -15,6 +15,7 @@ markierungen = ["Online", "Soziales"]
 paid = false
 slug = "wasistschön"
 title = "Bin ich schön? Was ist schön? Like oder nicht like..."
+arbeitsmaterial = "wasistscho%CC%88n_of8bbt"
 
 +++
 _In den sozialen Medien Fotos und Videos von sich teilen – wer macht das nicht? Dabei ist es den meisten wichtig, dabei auch gut auszusehen, so wie scheinbar alle anderen auch. Denn in den sozialen Medien wie Instagram, Snapchat oder TikTok sehen wir in sehr kurzer Zeit sehr viele Personen, die dem Schönheitsideal entsprechen._
@@ -38,5 +39,5 @@ Damit das nicht passiert, ist es wichtig, dass man sich immer wieder daran erinn
 {{< teiler >}}
 
 {{< arbeitsmaterial-group >}}
-{{< arbeitsmaterial file="wasistscho%CC%88n_of8bbt" >}}
+{{< arbeitsmaterial >}}
 {{< /arbeitsmaterial-group >}}

--- a/content/boris-johnson-und-sein-brexit.md
+++ b/content/boris-johnson-und-sein-brexit.md
@@ -15,6 +15,7 @@ markierungen = ["Großbritannien"]
 paid = false
 slug = "brexit"
 title = "Boris Johnson und \"sein\" Brexit"
+arbeitsmaterial = "brexit_fhv0qz"
 
 +++
 _England hat keinen Präsidenten, aber dafür ein Premierminister, der so etwas wie der Chef des Landes ist. Boris Johnson ist noch nicht lange der Chef, wirbelt aber Traditionen durcheinander. Er will Ende Oktober aus der EU austreten – wenn es sein muss, auf die harte Tour._
@@ -24,5 +25,5 @@ England gehört zur EU dazu. Nun hat ein bisschen mehr als die Hälfte des Volke
 {{< teiler >}}
 
 {{< arbeitsmaterial-group >}}
-{{< arbeitsmaterial file="brexit_fhv0qz" >}}
+{{< arbeitsmaterial >}}
 {{< /arbeitsmaterial-group >}}

--- a/content/das-kurdische-volk.md
+++ b/content/das-kurdische-volk.md
@@ -15,6 +15,7 @@ markierungen = ["Irak", "Iran", "Türkei", "Syrien", "Kriege/Konflikte"]
 paid = false
 slug = "kurdisches-volk"
 title = "Das kurdische Volk"
+arbeitsmaterial = "kurdische-volk-arbeitsmaterial_op1rav"
 
 +++
 _Die Kurden sind ein Volk, welches heute keinen eigenen Staat besitzt. Ihr Gebiet ist aufgeteilt auf die Türkei, Syrien, Iran und den Irak. Total sind das zirka 20 Millionen Menschen. Die meisten Kurden, zirka 13 Millionen leben in der Türkei. Es ist ein vielfältiges Volk._
@@ -38,5 +39,5 @@ Wenn ihr mehr zu den Kurden erfahren wollt, könnt ihr einen unserer bereits pub
 {{< teiler >}}
 
 {{< arbeitsmaterial-group >}}
-{{< arbeitsmaterial file="kurdische-volk-arbeitsmaterial_op1rav" >}}
+{{< arbeitsmaterial >}}
 {{< /arbeitsmaterial-group >}}

--- a/content/das-perfekte-auto.md
+++ b/content/das-perfekte-auto.md
@@ -15,6 +15,7 @@ markierungen = ["USA", "Energie"]
 paid = false
 slug = "elektroautos"
 title = "Das perfekte Auto"
+arbeitsmaterial = "das-perfekte-auto-arbeitsmaterial-2_vkd5xo"
 
 +++
 _Strom als neues Benzin. Die mögliche Zukunft der Automobilbranche - das sind Elektroautos. Anstatt mit unweltschädlichem Benzin oder Diesel fahren sie mit Strom. Sie sind (fast) lautlos und je nach Strombezug deutlich weniger umweltschädlich. Also das perfekte Auto?_
@@ -36,7 +37,5 @@ Fazit: Die Idee der Elektroautos sind gut, doch braucht es bessere und umweltfre
 {{< teiler >}}
 
 {{< arbeitsmaterial-group >}}
-{{< arbeitsmaterial file="das-perfekte-auto-arbeitsmaterial_mecdrd" >}}
-{{< arbeitsmaterial file= "das-perfekte-auto-arbeitsmaterial-2_vkd5xo" >}}
-{{< arbeitsmaterial file= "das-perfekte-auto-arbeitsmaterial-3_iskcfc" >}}
+{{< arbeitsmaterial >}}
 {{< /arbeitsmaterial-group >}}

--- a/content/der-grosse-krieg-ist-nicht-entstanden.was-ist-sonst-geschehen-im-iran.md
+++ b/content/der-grosse-krieg-ist-nicht-entstanden.was-ist-sonst-geschehen-im-iran.md
@@ -15,6 +15,7 @@ markierungen = ["Kriege/Konflikte", "Iran"]
 paid = false
 slug = "iran"
 title = "Der grosse Krieg ist nicht entstanden. Was ist sonst geschehen im Iran?"
+arbeitsmaterial = "iran-arbeitsmaterial_djnhsy"
 
 +++
 _Bald ist ein halbes Jahr vergangen, seit der iranische General Qasem Soleimani von einer Rakete der USA getötet wurde. Ein früherer Artikel der_ [_Jugendzytig_](https://www.jugendzytig.ch/kriegimiran) _ging damals der Frage nach, ob es vielleicht zu einem grossen Krieg zwischen den zwei Ländern kommt, die schon seit über 40 Jahren Streit haben. Was ist bisher geschehen? Die Chinderzytig rollt die Geschehnisse im Iran auf:_
@@ -40,5 +41,5 @@ Seit Januar dieses Jahres hat der Iran auch mit dem Corona-Virus zu kämpfen. Ne
 {{< teiler >}}
 
 {{< arbeitsmaterial-group >}}
-{{< arbeitsmaterial file="iran-arbeitsmaterial_djnhsy" >}}
+{{< arbeitsmaterial >}}
 {{< /arbeitsmaterial-group >}}

--- a/content/die-arbeiterpartei-kurdistan-pkk.md
+++ b/content/die-arbeiterpartei-kurdistan-pkk.md
@@ -15,6 +15,7 @@ markierungen = ["Syrian", "Parteien"]
 paid = false
 slug = "arbeiterpartei-kurdistan"
 title = "Die Arbeiterpartei Kurdistan (PKK)"
+arbeitsmaterial = "arbeiterpartei-kurdistan-arbeitsmaterial_vq9unb"
 
 +++
 _Die Arbeiterpartei Kurdistans (PKK) wurde 1978 durch Abdullah Öcalan gegründet. Er ist ein sehr harter Parteiführer. Er ist bekannt dafür, dass er auch mal zur Gewalt gegenüber Feinden und Parteimitgliedern, die nicht seiner Meinung sind, greift._
@@ -36,5 +37,5 @@ Wir haben in mehreren Artikeln über die Konflikte im nahen Osten berichtet. Die
 {{< teiler >}}
 
 {{< arbeitsmaterial-group >}}
-{{< arbeitsmaterial file="arbeiterpartei-kurdistan-arbeitsmaterial_vq9unb" >}}
+{{< arbeitsmaterial >}}
 {{< /arbeitsmaterial-group >}}

--- a/content/die-jagdsaison-warum-5560-hirsche-erschossen-werden.md
+++ b/content/die-jagdsaison-warum-5560-hirsche-erschossen-werden.md
@@ -15,6 +15,7 @@ markierungen = ["Schweiz", "Tierwelt"]
 paid = false
 slug = "jagdsaison"
 title = "Die Jagdsaison – Warum 5560 Hirsche erschossen werden"
+arbeitsmaterial = "jagsaison-arbeitsmaterial_td4zbb"
 
 +++
 _Im Kanton Graubünden startete am 3. September 2020 die Jagdsaison. Genauer gesagt: die Hochjagd. Diese dauerte bis zum 13. September 2020 und startet wieder am 21. September 2020. In dieser Zeit werden 5560 Hirsche gejagt. Auf der einen Seite ist das brutal. Auf der anderen hilft das dem Gleichgewicht der Natur._
@@ -45,5 +46,5 @@ Jagd in Graubünden:
 {{< teiler >}}
 
 {{< arbeitsmaterial-group >}}
-{{< arbeitsmaterial file="jagsaison-arbeitsmaterial_td4zbb" >}}
+{{< arbeitsmaterial >}}
 {{< /arbeitsmaterial-group >}}

--- a/content/die-kurden-in-syrien.md
+++ b/content/die-kurden-in-syrien.md
@@ -15,6 +15,7 @@ markierungen = ["Syrien", "Kriege/Konflikte"]
 paid = false
 slug = "kurden-in-syrien"
 title = "Die Kurden in Syrien"
+arbeitsmaterial = "kurden-in-syrien-arbeitsmaterial_qiuzsc"
 
 +++
 _Die Kurden sind mit etwa 35 Millionen Menschen das weltweit grösste Volk, das keinen eigenen Staat hat. Sie leben in der Türkei, im Iran, im Irak und in Syrien. Die Kurden haben eine gemeinsame Sprache und es verbindet sie eine starke Zusammengehörigkeit. In diesem Artikel wird die Situation der syrischen Kurden beleuchtet._
@@ -40,5 +41,5 @@ Rund 150’000 Frauen, Männer und Kinder sind wegen des türkischen Angriffs be
 {{< teiler >}}
 
 {{< arbeitsmaterial-group >}}
-{{< arbeitsmaterial file="kurden-in-syrien-arbeitsmaterial_qiuzsc" >}}
+{{< arbeitsmaterial >}}
 {{< /arbeitsmaterial-group >}}

--- a/content/ein-hoch-auf-das-pflegepersonal.md
+++ b/content/ein-hoch-auf-das-pflegepersonal.md
@@ -15,6 +15,7 @@ markierungen = ["Organisationen"]
 paid = false
 slug = "weltgesundheit"
 title = "Ein Hoch auf das Pflegepersonal"
+arbeitsmaterial = "Ein-Hoch-auf-das-Pflegepersonal-arbeitsmaterial_z9klkl"
 
 +++
 _Jedes Jahr am 7. April findet der Weltgesundheitstag statt. Warum braucht es den Weltgesundheitstag? Weil es immer wieder neue Themen zur Gesundheit gibt. Über diese müssen informiert werden._
@@ -34,5 +35,5 @@ Ihr habt sicher in letzter Zeit viel vom Coronavirus gehört. Personen müssen w
 {{< teiler >}}
 
 {{< arbeitsmaterial-group >}}
-{{< arbeitsmaterial file="Ein-Hoch-auf-das-Pflegepersonal-arbeitsmaterial_z9klkl" >}}
+{{< arbeitsmaterial >}}
 {{< /arbeitsmaterial-group >}}

--- a/content/fincen-files-ein-journalistennetzwerk-deckt-auf.md
+++ b/content/fincen-files-ein-journalistennetzwerk-deckt-auf.md
@@ -15,6 +15,7 @@ markierungen = ["Schweiz", "Rechte"]
 paid = false
 slug = "fincen-files"
 title = "Fincen Files – Ein Journalistennetzwerk deckt auf"
+arbeitsmaterial = "fincen-files_nn1uly"
 
 +++
 _"Statt in eine Armensiedlung, flossen Millionen in die Schweiz", so der Titel eines Artikels der Zeitung Der Bund vom 20. September 2020. Es geht um das Datenleck Fincen Files. Es wurde Geldwäscherei betrieben. Ein Journalistennetzwerk deckt auf. Was heisst das nun genau? Und was ist das?_
@@ -37,4 +38,4 @@ Wieviel Geld in welchen Ländern als illegal gilt, wieviele Reiche vom Geld für
 
 {{< teiler >}}
 
-{{< arbeitsmaterial-group >}} {{< arbeitsmaterial file="fincen-files_nn1uly" >}} {{< /arbeitsmaterial-group >}}
+{{< arbeitsmaterial-group >}} {{< arbeitsmaterial >}} {{< /arbeitsmaterial-group >}}

--- a/content/keine-corona-infizierten-in-nordkorea.md
+++ b/content/keine-corona-infizierten-in-nordkorea.md
@@ -15,6 +15,7 @@ markierungen = ["COVID19", "Nordkorea"]
 paid = false
 slug = "nordkorea-und-corona"
 title = "Keine Corona-Infizierten in Nordkorea?"
+arbeitsmaterial = "nordkorea-und-corona-arbeitsmaterial_ofbj21"
 
 +++
 _Aus dem Munde von Kim Jong-un, der seit seinem Amtsantritt 2011 als Oberster Führer Nordkoreas, weltweit für Aufregung sorgt, kam die Nachricht: Keine Covid-19-Infizierten in Nordkorea. Kann das sein?_
@@ -49,5 +50,5 @@ Frank, Rüdiger (2013) Nordkorea: Zwischen Stagnation und Veränderungsdruck. In
 {{< teiler >}}
 
 {{< arbeitsmaterial-group >}}
-{{< arbeitsmaterial file="nordkorea-und-corona-arbeitsmaterial_ofbj21" >}}
+{{< arbeitsmaterial >}}
 {{< /arbeitsmaterial-group >}}

--- a/content/kreislaufwirtschaft.md
+++ b/content/kreislaufwirtschaft.md
@@ -15,6 +15,7 @@ markierungen = ["Klimawandel"]
 paid = false
 slug = "kreislaufwirtschaft"
 title = "Kreislaufwirtschaft"
+arbeitsmaterial = "Kreislaufwirtschaft-arbeitsmaterial_fgferx"
 
 +++
 _Die Kreislaufwirtschaft verursacht weniger Abfälle und schont die Umwelt. Doch wie schafft sie das genau?_
@@ -48,5 +49,5 @@ Am 17. September 2020 fand die Konferenz zur Kreislaufwirtschaft statt. Diese Ko
 {{< teiler >}}
 
 {{< arbeitsmaterial-group >}}
-{{< arbeitsmaterial file="Kreislaufwirtschaft-arbeitsmaterial_fgferx" >}}
+{{< arbeitsmaterial >}}
 {{< /arbeitsmaterial-group >}}

--- a/content/nessie-das-ungeheuer-von-loch-ness.md
+++ b/content/nessie-das-ungeheuer-von-loch-ness.md
@@ -15,6 +15,7 @@ markierungen = ["Schottland", "Tierwelt"]
 paid = false
 slug = "sagenhafte-tiere-teil-2-nessie"
 title = "Nessie: Das Ungeheuer von Loch Ness"
+arbeitsmaterial = "loch-ness-monster-arbeitsmaterial_c3qd3p"
 
 +++
 ### **Serie: Sagenhafte Tiere**
@@ -46,4 +47,4 @@ So hat sich im Laufe der Jahrhunderte das Bild der Sagengestalt gewandelt. Aus d
 
 {{< teiler >}}
 
-{{< arbeitsmaterial-group >}} {{< arbeitsmaterial file="loch-ness-monster-arbeitsmaterial_c3qd3p" >}} {{< /arbeitsmaterial-group >}}
+{{< arbeitsmaterial-group >}} {{< arbeitsmaterial >}} {{< /arbeitsmaterial-group >}}

--- a/content/palastinensischer-terrorismus.md
+++ b/content/palastinensischer-terrorismus.md
@@ -15,6 +15,7 @@ markierungen = ["Palästina", "Kriege/Konflikte"]
 paid = false
 slug = "palaestinensischer-terrorismus"
 title = "Palästinensischer Terrorismus"
+arbeitsmaterial = "palaestinensischer-terrorismus-arbeitsmaterial_xz6iwc"
 
 +++
 _Terroristische Anschläge von Palästinensern prägten die Zeit von 1960 bis 1980. Diese Anschläge tauchen noch heute in vielen Schlagzeilen der Zeitungen auf. Wer genau verübte die Anschläge und aus welchem Grund? Und warum beeinflussen sie unsere Nachrichten noch heute?_
@@ -44,5 +45,5 @@ Riegler, Thomas (2018): «Das «Spinnennetz» des internationalen Terrorismus- D
 {{< teiler >}}
 
 {{< arbeitsmaterial-group >}}
-{{< arbeitsmaterial file="palaestinensischer-terrorismus-arbeitsmaterial_xz6iwc" >}}
+{{< arbeitsmaterial >}}
 {{< /arbeitsmaterial-group >}}

--- a/content/quarantane-nach-den-herbstferien.md
+++ b/content/quarantane-nach-den-herbstferien.md
@@ -15,6 +15,7 @@ markierungen = ["COVID19", "Schweiz"]
 paid = false
 slug = "quarantaene-nach-den-herbstferien"
 title = "Quarantäne nach den Herbstferien?"
+arbeitsmaterial = "Quaranta%CC%88ne_AM_sg_eq9vfo"
 
 +++
 _Wer in den Herbstferien im Ausland war, muss sich jetzt vielleicht in Quarantäne begeben._
@@ -42,5 +43,5 @@ Die vollständige Liste der Risikoländer: [https://www.bag.admin.ch/bag/de/home
 {{< teiler >}}
 
 {{< arbeitsmaterial-group >}}
-{{< arbeitsmaterial file="Quaranta%CC%88ne_AM_sg_eq9vfo" >}}
+{{< arbeitsmaterial >}}
 {{< /arbeitsmaterial-group >}}

--- a/content/radioaktiver-abfall-vergessen-ist-gefahrlich.md
+++ b/content/radioaktiver-abfall-vergessen-ist-gefahrlich.md
@@ -15,6 +15,7 @@ markierungen = ["Energie"]
 paid = false
 slug = "radioaktivitaet"
 title = "Radioaktiver Abfall: Vergessen ist gefährlich"
+arbeitsmaterial = "radioaktiver-abfall-arbeitsmaterial_lxfevk"
 
 +++
 _Radioaktives Material ist sehr schädlich – und das viele tausend Jahre lang. Die Menschen stehen deshalb heute vor einer seltsamen, aber ernsten Aufgabe: Sie müssen die Menschen in der Zukunft warnen._
@@ -33,5 +34,5 @@ Forscherinnen und Forscher machen sich deshalb schon heute Gedanken, wie man die
 {{< teiler >}}
 
 {{< arbeitsmaterial-group >}}
-{{< arbeitsmaterial file="radioaktiver-abfall-arbeitsmaterial_lxfevk" >}}
+{{< arbeitsmaterial >}}
 {{< /arbeitsmaterial-group >}}

--- a/content/rotes-quecksilber-ein-gefahrliches-gerucht.md
+++ b/content/rotes-quecksilber-ein-gefahrliches-gerucht.md
@@ -15,6 +15,7 @@ markierungen = []
 paid = false
 slug = "rotesquecksilber"
 title = "Rotes Quecksilber – ein gefährliches Gerücht"
+arbeitsmaterial = "rotesquecksilber_jrs9u3"
 
 +++
 _Mit rotem Quecksilber könne man auf einfache Weise eine Atombombe bauen. Das glauben Terroristen und Schatzsucher. Der Stoff existiert in Wirklichkeit aber gar nicht._

--- a/content/schrott-im-weltraum.md
+++ b/content/schrott-im-weltraum.md
@@ -15,6 +15,8 @@ markierungen = ["Weltall"]
 paid = false
 slug = "weltraumschrott"
 title = "Schrott im Weltraum"
+arbeitsmaterial = "schrott-im-weltraum-arbeitsmaterial_bui64q"
+
 
 +++
 _Während auf der Erde ein Virus unkontrolliert herumschwirrt, schwirren im Weltraum Unmengen von alten Satelliten und Raketenteilen unkontrolliert um die Erde. Für Astronauten ist der Weltraumschrott eine grosse Gefahr._
@@ -40,7 +42,5 @@ Für uns auf der Erde ist der Schrott zum Glück nicht gefährlich. Wenn er zu n
 {{< teiler >}}
 
 {{< arbeitsmaterial-group >}}
-{{< arbeitsmaterial file="schrott-im-weltraum-arbeitsmaterial_bui64q" >}}
-
-{{< arbeitsmaterial file="schrott-im-weltraum-arbeitsmaterial-2_acgnid" >}}
+{{< arbeitsmaterial >}}
 {{< /arbeitsmaterial-group >}}

--- a/content/seit-fast-70-jahren-fliegt-sie-durch-die-lufte.md
+++ b/content/seit-fast-70-jahren-fliegt-sie-durch-die-lufte.md
@@ -15,6 +15,7 @@ markierungen = ["Schweiz", "Organisationen"]
 paid = false
 slug = "rega"
 title = "Seit fast 70 Jahren fliegt sie durch die Lüfte"
+arbeitsmaterial = "rega-arbeitsmaterial_g35awb"
 
 +++
 _Du hörst sie schon von weitem, die Helikopter. Eine Faszination für jeden: Die Rega kommt zu Hilfe, wenn sich jemand verletzt hat und die Ambulanz nicht gut hinkommt._
@@ -45,4 +46,4 @@ Rega Homepage: [https://www.rega.ch/](https://www.rega.ch/ "https://www.rega.ch/
 
 {{< teiler >}}
 
-{{< arbeitsmaterial-group >}} {{< arbeitsmaterial file="rega-arbeitsmaterial_g35awb" >}} {{< /arbeitsmaterial-group >}}
+{{< arbeitsmaterial-group >}} {{< arbeitsmaterial >}} {{< /arbeitsmaterial-group >}}

--- a/content/strahlen-tag-und-nacht.md
+++ b/content/strahlen-tag-und-nacht.md
@@ -15,6 +15,7 @@ markierungen = ["Energie"]
 paid = false
 slug = "handystrahlung"
 title = "Strahlen - Tag und Nacht"
+arbeitsmaterial = "handystrahlung-arbeitsmaterial_jsjfdo"
 
 +++
 _Strahlen gibt es überall, jedoch sind sie nicht immer nicht sichtbar. Es gibt viele Arten von Strahlung in unserem Alltag. Sind Strahlen gefährlich? Müssen wir uns vor diesen schützen? Welche Strahlen gibt es?_
@@ -43,5 +44,5 @@ Hier ist eine kurze Erklärung zu diesen Begriffen.
 {{< teiler >}}
 
 {{< arbeitsmaterial-group >}}
-{{< arbeitsmaterial file="handystrahlung-arbeitsmaterial_jsjfdo" >}}
+{{< arbeitsmaterial >}}
 {{< /arbeitsmaterial-group >}}

--- a/content/unsere-ladenserie-teil-2-coop.md
+++ b/content/unsere-ladenserie-teil-2-coop.md
@@ -15,6 +15,7 @@ markierungen = ["Schweiz"]
 paid = false
 slug = "ladenserie-coop"
 title = "Unsere Ladenserie: Teil 2 – Coop"
+arbeitsmaterial = "Arbeitsmaterial_Coop_vpj99d"
 
 +++
 _Coop ist 1969 aus verschiedenen «Konsumvereinen» entstanden. Heute hat der Detailhändler das dichteste Netz an Filialen in der Schweiz._
@@ -54,5 +55,5 @@ Migros und Coop verfolgen eine ähnliche Strategie. Beide versuchen stark zu wac
 {{< teiler >}}
 
 {{< arbeitsmaterial-group >}}
-{{< arbeitsmaterial file="Arbeitsmaterial_Coop_vpj99d" >}}
+{{< arbeitsmaterial >}}
 {{< /arbeitsmaterial-group >}}

--- a/content/unsere-ladenserie-teil-3-aldi-und-lidl.md
+++ b/content/unsere-ladenserie-teil-3-aldi-und-lidl.md
@@ -15,6 +15,7 @@ markierungen = ["Schweiz"]
 paid = false
 slug = "ladenserie-3-aldi-und-lidl"
 title = "Unsere Ladenserie: Teil 3 – Aldi und Lidl"
+arbeitsmaterial = "Arbeitsmaterial_Aldi_Lidl_mitLoesungen_t8g0wu"
 
 +++
 _Vor etwas mehr als 10 Jahren kamen Aldi und Lidl in die Schweiz – der Einzug der Billig-Läden sorgte für Aufsehen und Spekulationen._
@@ -38,5 +39,5 @@ Dass man mit billigen Produkten viel Geld verdienen kann, zeigt übrigens Karl H
 {{< teiler >}}
 
 {{< arbeitsmaterial-group >}}
-{{< arbeitsmaterial file="Arbeitsmaterial_Aldi_Lidl_mitLoesungen_t8g0wu" >}}
+{{< arbeitsmaterial >}}
 {{< /arbeitsmaterial-group >}}

--- a/content/unsere-ladenserie-teil-4-denner-volg-und-spar.md
+++ b/content/unsere-ladenserie-teil-4-denner-volg-und-spar.md
@@ -15,6 +15,7 @@ markierungen = []
 paid = false
 slug = "ladenserie4-spar-denner-volg"
 title = "Unsere Ladenserie: Teil 4 – Denner, Volg und Spar"
+arbeitsmaterial = "Arbeitsmaterial_Ladenserie_DennerVolgundSpar_c5kkc2"
 
 +++
 _Im letzten Teil der Serie zu den Detailhändlern stellen wir vor: Denner, Volg und Spar._
@@ -50,5 +51,5 @@ In der Schweiz gibt es 2‘202 Gemeinden. Jede Gemeinde hat im Durchschnitt also
 {{< teiler >}}
 
 {{< arbeitsmaterial-group >}}
-{{< arbeitsmaterial file="Arbeitsmaterial_Ladenserie_DennerVolgundSpar_c5kkc2" >}}
+{{< arbeitsmaterial >}}
 {{< /arbeitsmaterial-group >}}

--- a/content/warum-singen-vogel.md
+++ b/content/warum-singen-vogel.md
@@ -15,6 +15,7 @@ markierungen = ["Tierwelt"]
 paid = false
 slug = "warumsingenvoegel"
 title = "Warum singen Vögel?"
+arbeitsmaterial = "warum-singen-voegel-arbeitsmaterial_b1bv4h"
 
 +++
 _Hübsch zwitschern die Vögel in den Bäumen. Aber wieso machen sie das eigentlich?_
@@ -43,7 +44,7 @@ Der Gesang hat also mehrere Funktionen: Als Markierung des Reviers, als Lockruf 
 {{< teiler >}}
 
 {{< arbeitsmaterial-group >}}
-{{< arbeitsmaterial file="warum-singen-voegel-arbeitsmaterial_b1bv4h" >}}
+{{< arbeitsmaterial >}}
 {{< /arbeitsmaterial-group >}}
 
-### 
+###

--- a/content/wer-kann-lesen-und-schreiben.md
+++ b/content/wer-kann-lesen-und-schreiben.md
@@ -15,6 +15,7 @@ markierungen = ["Soziales"]
 paid = false
 slug = "weltalphabetisierungstag"
 title = "Wer kann lesen und schreiben?"
+arbeitsmaterial = "welt-alphabetisierungs-tag-arbeitsmateral_bsb4mx"
 
 +++
 _Immer noch können mehr als 700 Millionen Erwachsene nicht lesen und schreiben. Häufig stammen sie aus Afrika._
@@ -41,4 +42,4 @@ Am 8. September ist der Welttag der Alphabetisierung. An diesem Tag will die {{<
 
 {{< teiler >}}
 
-{{< arbeitsmaterial-group >}} {{< arbeitsmaterial file="welt-alphabetisierungs-tag-arbeitsmateral_bsb4mx" >}} {{< /arbeitsmaterial-group >}}
+{{< arbeitsmaterial-group >}} {{< arbeitsmaterial >}} {{< /arbeitsmaterial-group >}}

--- a/content/yeti-der-schneemensch-aus-dem-himalaya.md
+++ b/content/yeti-der-schneemensch-aus-dem-himalaya.md
@@ -15,6 +15,7 @@ markierungen = ["Tibet", "Tierwelt"]
 paid = false
 slug = "sagenhaftetiere-teil1-yeti"
 title = "Yeti: Der Schneemensch aus dem Himalaya"
+arbeitsmaterial = "yeti-arbeitsmaterial_yj1uzu"
 
 +++
 ### Serie: Sagenhafte Tiere
@@ -47,5 +48,5 @@ Die bekannteste Yeti-Sichtung stammt von Reinhold Messner. Der berühmte österr
 {{< teiler >}}
 
 {{< arbeitsmaterial-group >}}
-{{< arbeitsmaterial file="yeti-arbeitsmaterial_yj1uzu" >}}
+{{< arbeitsmaterial >}}
 {{< /arbeitsmaterial-group >}}

--- a/data/partials/footer.yaml
+++ b/data/partials/footer.yaml
@@ -3,6 +3,8 @@ main:
     link: "/alle-artikel"
   - label: Fokus der Woche
     link: "/fokus-der-woche"
+  - label: Arbeitsmaterial
+    link: "/arbeitsmaterial"
   - label: Abonnemente
     link: "/abonnemente"
   - label: Der Verein

--- a/layouts/_default/arbeitsmaterial.html
+++ b/layouts/_default/arbeitsmaterial.html
@@ -1,0 +1,3 @@
+{{ define "main" }}
+
+{{ end }}

--- a/layouts/_default/arbeitsmaterial.html
+++ b/layouts/_default/arbeitsmaterial.html
@@ -1,3 +1,23 @@
 {{ define "main" }}
-
+	<section class="arbeitsmaterial__container">
+		<h2 class="heading heading__secondary">arbeitsmaterial</h2>
+		<div class="arbeitsmaterial__list">
+			{{ range where (where .Site.Pages ".Params.artikel" true) ".Params.fdw" false }}
+				{{ if isset .Params "arbeitsmaterial" }}
+					<div class="arbeitsmaterial__card">
+						<div class="arbeitsmaterial__card-upper">
+							<h3 class="arbeitsmaterial__card-title">{{ .Params.title }}</h3>
+						</div>
+						<div class="arbeitsmaterial__card-lower">
+							<img src="{{ .Site.Params.cloudinary_url }}/bo_2px_solid_rgb:000000,c_scale,h_200,q_auto:best/{{ .Params.arbeitsmaterial }}.png" alt="Arbeitsmaterial cover" class="arbeitsmaterial-sc__file">
+							<div class="arbeitsmaterial__card-btns">
+								<a href="{{ .Permalink }}" class="btn btn--primary arbeitsmaterial__card-btn">Artikel</a>
+								<a href="/markierungen/covid19" class="btn btn--secondary arbeitsmaterial__card-btn">PDF</a>
+							</div>
+						</div>
+					</div>
+				{{ end }}
+			{{ end }}
+		</div>
+	</section>
 {{ end }}

--- a/layouts/_default/arbeitsmaterial.html
+++ b/layouts/_default/arbeitsmaterial.html
@@ -3,7 +3,7 @@
 		<h2 class="heading heading__secondary">arbeitsmaterial</h2>
 		<div class="card__container">
 			{{ $arbeitsmaterial := where (where .Site.Pages ".Params.artikel" true) ".Params.fdw" false }}
-			{{ range $arbeitsmaterial.ByDate.Reverse }}
+			{{ range $arbeitsmaterial.ByTitle }}
 				{{ if isset .Params "arbeitsmaterial" }}
 					<div class="arbeitsmaterial__card">
 						<div class="arbeitsmaterial__card-upper">

--- a/layouts/_default/arbeitsmaterial.html
+++ b/layouts/_default/arbeitsmaterial.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 	<section class="arbeitsmaterial__container">
 		<h2 class="heading heading__secondary">arbeitsmaterial</h2>
-		<div class="arbeitsmaterial__list">
+		<div class="card__container">
 			{{ range where (where .Site.Pages ".Params.artikel" true) ".Params.fdw" false }}
 				{{ if isset .Params "arbeitsmaterial" }}
 					<div class="arbeitsmaterial__card">

--- a/layouts/_default/arbeitsmaterial.html
+++ b/layouts/_default/arbeitsmaterial.html
@@ -5,7 +5,7 @@
 			{{ $arbeitsmaterial := where (where .Site.Pages ".Params.artikel" true) ".Params.fdw" false }}
 			{{ range $arbeitsmaterial.ByTitle }}
 				{{ if isset .Params "arbeitsmaterial" }}
-					<div class="arbeitsmaterial__card">
+					<div class="arbeitsmaterial__card card__hidden">
 						<div class="arbeitsmaterial__card-upper">
 							<h3 class="arbeitsmaterial__card-title">{{ .Params.title }}</h3>
 						</div>
@@ -24,6 +24,9 @@
 				{{ end }}
 			{{ end }}
 			<div class="card card__buffer"></div>
+		</div>
+		<div class="btn__container">
+			<a href="#" class="btn btn--primary" id="loadMore">Mehr Arbeitsmaterial</a>
 		</div>
 	</section>
 {{ end }}

--- a/layouts/_default/arbeitsmaterial.html
+++ b/layouts/_default/arbeitsmaterial.html
@@ -12,7 +12,11 @@
 							<img src="{{ .Site.Params.cloudinary_url }}/bo_2px_solid_rgb:000000,c_scale,h_200,q_auto:best/{{ .Params.arbeitsmaterial }}.png" alt="Arbeitsmaterial cover" class="arbeitsmaterial-sc__file">
 							<div class="arbeitsmaterial__card-btns">
 								<a href="{{ .Permalink }}" class="btn btn--primary arbeitsmaterial__card-btn">Artikel</a>
-								<a href="/markierungen/covid19" class="btn btn--secondary arbeitsmaterial__card-btn">PDF</a>
+								<a href="{{ .Site.Params.cloudinary_url }}/{{ .Page.Params.arbeitsmaterial }}.pdf"
+									target="_blank"
+									class="btn btn--secondary arbeitsmaterial__card-btn">
+									PDF
+								</a>
 							</div>
 						</div>
 					</div>

--- a/layouts/_default/arbeitsmaterial.html
+++ b/layouts/_default/arbeitsmaterial.html
@@ -2,7 +2,8 @@
 	<section class="arbeitsmaterial__container">
 		<h2 class="heading heading__secondary">arbeitsmaterial</h2>
 		<div class="card__container">
-			{{ range where (where .Site.Pages ".Params.artikel" true) ".Params.fdw" false }}
+			{{ $arbeitsmaterial := where (where .Site.Pages ".Params.artikel" true) ".Params.fdw" false }}
+			{{ range $arbeitsmaterial.ByDate.Reverse }}
 				{{ if isset .Params "arbeitsmaterial" }}
 					<div class="arbeitsmaterial__card">
 						<div class="arbeitsmaterial__card-upper">

--- a/layouts/_default/arbeitsmaterial.html
+++ b/layouts/_default/arbeitsmaterial.html
@@ -23,6 +23,7 @@
 					</div>
 				{{ end }}
 			{{ end }}
+			<div class="card card__buffer"></div>
 		</div>
 	</section>
 {{ end }}

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -8,6 +8,7 @@
 		<ul class="menu__nav-list">
 			<li class="menu__nav-item"><a href="/alle-artikel" class="menu__nav-link">Artikel</a></li>
 			<li class="menu__nav-item"><a href="/fokus-der-woche" class="menu__nav-link">Fokus der Woche</a></li>
+			<li class="menu__nav-item"><a href="/arbeitsmaterial" class="menu__nav-link">Arbeitsmaterial</a></li>
 			<li class="menu__nav-item"><a href="/abonnemente" class="menu__nav-link">Abonnemente</a></li>
 			<li class="menu__nav-item"><a href="/verein" class="menu__nav-link">Der Verein</a></li>
 			<li class="menu__nav-item"><a href="/kontakt" class="menu__nav-link">Kontaktiere Uns</a></li>

--- a/layouts/shortcodes/arbeitsmaterial-group.html
+++ b/layouts/shortcodes/arbeitsmaterial-group.html
@@ -1,6 +1,6 @@
-<div class="arbeitsmaterial-group">
-	<h3 class="arbeitsmaterial__heading">Arbeitsmaterial</h3>
-	<div class="arbeitsmaterial__container">
+<div class="arbeitsmaterial-sc-group">
+	<h3 class="arbeitsmaterial-sc__heading">Arbeitsmaterial</h3>
+	<div class="arbeitsmaterial-sc__container">
 		{{ .Inner }}
 	</div>
 </div>

--- a/layouts/shortcodes/arbeitsmaterial.html
+++ b/layouts/shortcodes/arbeitsmaterial.html
@@ -1,4 +1,4 @@
-<a href="{{ .Site.Params.cloudinary_url }}/{{ .Page.Params.arbeitsmaterial }}.pdf" target="_blank" class="arbeitsmaterial__link">
-	<img src="{{ .Site.Params.cloudinary_url }}/bo_1px_solid_rgb:000000,c_scale,h_200,q_auto:best/{{ .Page.Params.arbeitsmaterial }}.png" alt="Arbeitsmaterial cover" class="arbeitsmaterial__file">
-	<div class="arbeitsmaterial__file-name">PDF</div>
+<a href="{{ .Site.Params.cloudinary_url }}/{{ .Page.Params.arbeitsmaterial }}.pdf" target="_blank" class="arbeitsmaterial-sc__link">
+	<img src="{{ .Site.Params.cloudinary_url }}/bo_1px_solid_rgb:000000,c_scale,h_200,q_auto:best/{{ .Page.Params.arbeitsmaterial }}.png" alt="Arbeitsmaterial cover" class="arbeitsmaterial-sc__file">
+	<div class="arbeitsmaterial-sc__file-name">PDF</div>
 </a>

--- a/layouts/shortcodes/arbeitsmaterial.html
+++ b/layouts/shortcodes/arbeitsmaterial.html
@@ -1,4 +1,4 @@
-<a href="{{ .Site.Params.cloudinary_url }}/{{ .Get `file`}}.pdf" target="_blank" class="arbeitsmaterial__link">
-	<img src="{{ .Site.Params.cloudinary_url }}/bo_1px_solid_rgb:000000,c_scale,h_200,q_auto:best/{{ .Get `file`}}.png" alt="Arbeitsmaterial cover" class="arbeitsmaterial__file">
+<a href="{{ .Site.Params.cloudinary_url }}/{{ .Page.Params.arbeitsmaterial }}.pdf" target="_blank" class="arbeitsmaterial__link">
+	<img src="{{ .Site.Params.cloudinary_url }}/bo_1px_solid_rgb:000000,c_scale,h_200,q_auto:best/{{ .Page.Params.arbeitsmaterial }}.png" alt="Arbeitsmaterial cover" class="arbeitsmaterial__file">
 	<div class="arbeitsmaterial__file-name">PDF</div>
 </a>


### PR DESCRIPTION
Created Arbeitsmaterial page that lists the arbeitsmaterial from every article that has it, with a link to the pdf and a link to the article itself. This was request from Melanie as she informed us that is was hard for both teachers and students to locate the article so they could access the material.

![CleanShot 2020-10-18 at 22 19 15](https://user-images.githubusercontent.com/16960228/96380865-0d3d0e00-1190-11eb-8946-462a9cfec282.gif)

This is only a short term fix until I get the search functionality feature added to the website. Eventually this page will become too long and search will be the only way forward.