### PR TITLE
Schweizer Medien logo update

### DIFF
--- a/assets/sass/layout/_footer.scss
+++ b/assets/sass/layout/_footer.scss
@@ -63,6 +63,10 @@
 		display: flex;
 		align-items: center;
 
+		@include respond(tab-land) { margin-left: 5rem; }
+
+		@include respond(phone-sm) { margin-left: 0; }
+
 		&-line {
 			height: 5rem;
 			border-right: 1px solid $chinder-platinum;
@@ -77,7 +81,7 @@
 
 	&__line {
 		width: 10rem;
-		margin-top: 2rem;
+		margin: 2rem 0;
 		border-bottom: 1px solid $chinder-platinum;
 		display: none;
 

--- a/assets/sass/layout/_footer.scss
+++ b/assets/sass/layout/_footer.scss
@@ -55,23 +55,23 @@
 		}
 	}
 
-	&__logo-group {
+	&__partner {
+		color: $chinder-platinum;
+		font-weight: 500;
+		font-size: 1.2rem;
+		text-decoration: none;
 		display: flex;
 		align-items: center;
 
-		@include respond(phone-xl) {
-			flex-direction: column;
+		&-line {
+			height: 5rem;
+			border-right: 1px solid $chinder-platinum;
+			margin: 0 1rem;
 		}
-	}
 
-	&__chinderzytig {
-		display: flex;
-		align-items: center;
-		margin-right: 2rem;
-
-		@include respond(phone-xl) {
-			margin-right: 0;
-			margin-bottom: 2rem;
+		&-list {
+			list-style: none;
+			padding: 0;
 		}
 	}
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -29,7 +29,7 @@
 			<div class="footer__partner-line"></div>
 			<ul class="footer__partner-list">
 				<li class="footer__partner-text">Offizieller</li>
-				<li class="footer__partner-text">Netwerkpartner</li>
+				<li class="footer__partner-text">Netzwerkpartner</li>
 				<li class="footer__partner-text">Verband</li>
 			</ul>
 		</a>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -24,15 +24,15 @@
 		</div>
 	</div>
 	<div class="footer__bottom">
-		<div class="footer__logo-group">
-			<div class="footer__chinderzytig">
-				<img src="{{ .Site.Params.cloudinary_url }}/c_scale,h_62,q_auto:good,w_100/v1594391535/logos/chinder_main_grey_hifabo.png" alt="Chinderzytig logo">
-				<span class="footer__chinderzytig-text">Chinderzytig</span>
-			</div>
-			<a href="https://www.schweizermedien.ch/medienkompetenz/angebote-netzwerkpartner" class="footer__medien">
-				<img src="{{ .Site.Params.cloudinary_url }}/c_scale,q_auto:good,w_200/v1595591559/logos/sm_grey_sx76sk.png" alt="Schweizer Medien logo">
-			</a>
-		</div>
+		<a href="https://www.schweizermedien.ch/medienkompetenz/angebote-netzwerkpartner" class="footer__partner">
+			<img src="{{ .Site.Params.cloudinary_url }}/c_scale,q_auto:good,w_200/v1595591559/logos/sm_grey_sx76sk.png" alt="Schweizer Medien logo" class="footer__partner-logo" >
+			<div class="footer__partner-line"></div>
+			<ul class="footer__partner-list">
+				<li class="footer__partner-text">Offizieller</li>
+				<li class="footer__partner-text">Netwerkpartner</li>
+				<li class="footer__partner-text">Verband</li>
+			</ul>
+		</a>
 		<div class="footer__line"></div>
 		<div class="footer__social-group">
 			{{- partial "svgs/social_svgs.html" . -}}


### PR DESCRIPTION
Made the following changes to the logo group in the footer:
- Removed Chinderzytig logo
- Added "Offizieller Netzwerkpartner Verband" as requested in development ticket: https://trello.com/c/1HS2obb4/173-verband-schweizer-medien