### PR TITLE
Arbeitsmaterial CTA

### DIFF
--- a/assets/sass/layout/_print_format.scss
+++ b/assets/sass/layout/_print_format.scss
@@ -21,6 +21,7 @@
 	figcaption.single__image-caption { margin-left: 70pt; }
 
 	.single__container .single__content {
+		border-bottom: none;
 
 		h3 { font: 16pt Georgia, "Times New Roman", Times, serif; }
 
@@ -42,9 +43,14 @@
 			figcaption.image__caption { margin-left: 70pt;}
 		}
 
-		.single__content-video { display: none; }
-
+		.single__content-video,
 		.container__center { display: none; }
+	}
+
+	.single__content:after {
+		content: "Passendes Arbeitsmaterial zu diesem Artikel auf www.chinderzytig.ch";
+		font-weight: 700;
+		font-style: italic;
 	}
 }
 


### PR DESCRIPTION
As requested by Lars, added an Arbeitsmaterial call to action at the bottom of a article when being printed:

![CleanShot 2020-11-07 at 12 56 35@2x](https://user-images.githubusercontent.com/16960228/98440503-60eca880-20f9-11eb-95bc-316c9008855e.png)
