### PR TITLE
Z index fixes

### DIFF
--- a/assets/sass/components/_definition.scss
+++ b/assets/sass/components/_definition.scss
@@ -8,7 +8,7 @@
 	opacity: 0;
 	visibility: hidden;
 	transition: all .3s;
-	z-index: 10000;
+	z-index: 2147483640;
 
 	&:target {
 		opacity: 1;

--- a/assets/sass/components/_definition.scss
+++ b/assets/sass/components/_definition.scss
@@ -8,7 +8,7 @@
 	opacity: 0;
 	visibility: hidden;
 	transition: all .3s;
-	z-index: 2147483640;
+	z-index: 2300000000;
 
 	&:target {
 		opacity: 1;

--- a/assets/sass/components/_definition.scss
+++ b/assets/sass/components/_definition.scss
@@ -8,7 +8,7 @@
 	opacity: 0;
 	visibility: hidden;
 	transition: all .3s;
-	z-index: 999;
+	z-index: 10000;
 
 	&:target {
 		opacity: 1;

--- a/assets/sass/components/_menu.scss
+++ b/assets/sass/components/_menu.scss
@@ -1,4 +1,5 @@
 .menu {
+	z-index: 2299999999;
 
 	&__checkbox {
 		display: none;


### PR DESCRIPTION
Fixed `z-index` discrepancies, primarily relating to the osano cookie widget and its `z-index` positioning being higher than:

the definition overlay:
![CleanShot 2020-11-08 at 20 34 43@2x](https://user-images.githubusercontent.com/16960228/98482483-0e4ae380-2202-11eb-8c42-0eaf4b72f87e.png)

the menu background:
![CleanShot 2020-11-08 at 20 35 14@2x](https://user-images.githubusercontent.com/16960228/98482493-1a36a580-2202-11eb-964e-fb0d29ad8925.png)
