### PR TITLE
Restructure footer links

### DIFF
--- a/assets/sass/layout/_footer.scss
+++ b/assets/sass/layout/_footer.scss
@@ -48,6 +48,8 @@
 			}
 		}
 
+		&-right { align-self: flex-end; }
+
 		@include respond(tab-land) { padding: 2rem 3rem; }
 
 		@include respond(tab-port-lg) {
@@ -99,7 +101,7 @@
 		}
 	}
 
-	&__line {
+	&__line-horizontal {
 		width: 10rem;
 		margin: 2rem 0;
 		border-bottom: 1px solid $chinder-platinum;

--- a/assets/sass/layout/_footer.scss
+++ b/assets/sass/layout/_footer.scss
@@ -28,6 +28,26 @@
 		justify-content: space-between;
 		align-items: center;
 
+		&-links {
+			list-style: none;
+			padding-left: 0;
+			display: flex;
+			margin-bottom: 6rem;
+		}
+
+		&-item {
+
+			&:not(:last-child) {
+				margin-right: 2rem;
+
+				&:after {
+					content: "|";
+					color: $chinder-platinum;
+					margin-left: 2rem;
+				}
+			}
+		}
+
 		@include respond(tab-land) { padding: 2rem 3rem; }
 
 		@include respond(tab-port-lg) {

--- a/assets/sass/layout/_footer.scss
+++ b/assets/sass/layout/_footer.scss
@@ -28,33 +28,56 @@
 		justify-content: space-between;
 		align-items: center;
 
-		&-links {
-			list-style: none;
-			padding-left: 0;
-			display: flex;
-			margin-bottom: 6rem;
-		}
-
-		&-item {
-
-			&:not(:last-child) {
-				margin-right: 2rem;
-
-				&:after {
-					content: "|";
-					color: $chinder-platinum;
-					margin-left: 2rem;
-				}
-			}
-		}
-
-		&-right { align-self: flex-end; }
-
 		@include respond(tab-land) { padding: 2rem 3rem; }
 
 		@include respond(tab-port-lg) {
 			flex-direction: column-reverse;
 			padding: 3rem 0;
+		}
+
+		&-links {
+			list-style: none;
+			padding-left: 0;
+			display: flex;
+			margin-bottom: 6rem;
+
+			@include respond(tab-port-lg) { margin: 3rem 0 0 0; }
+
+			@include respond(phone-md) { margin-left: 5rem; }
+
+		}
+
+		&-item {
+
+			&:not(:last-child) {
+
+				&:after {
+					content: "|";
+					color: $chinder-platinum;
+					margin: 0 2rem;
+
+					@include respond(phone-lg) { margin: 0 0.5rem; }
+				}
+			}
+		}
+
+		&-right {
+			align-self: flex-end;
+
+			@include respond(tab-port-lg) { align-self: center; }
+		}
+
+		&-left {
+			display: flex;
+			flex-direction: column;
+
+			@include respond(tab-land) { margin-left: 5rem; }
+
+			@include respond(tab-port-lg) {
+				flex-direction: column-reverse;
+				align-items: center;
+				margin-left: 0;
+			}
 		}
 	}
 
@@ -84,8 +107,6 @@
 		text-decoration: none;
 		display: flex;
 		align-items: center;
-
-		@include respond(tab-land) { margin-left: 5rem; }
 
 		@include respond(phone-sm) { margin-left: 0; }
 

--- a/data/partials/footer.yaml
+++ b/data/partials/footer.yaml
@@ -13,12 +13,6 @@ main:
     link: "/verein"
   - label: Kontakt
     link: "/kontakt"
-  - label: Datenschutz
-    link: "/datenschutz"
-  - label: Seitenverzeichnis
-    link: "/sitemap.xml"
-  - label: Admin
-    link: "/admin"
 left:
   - label: Nordamerika
     link: "/kategorien/nordamerika"
@@ -49,3 +43,10 @@ right:
     link: "/kategorien/weltraum/universum"
   - label: Welt
     link: "/kategorien/welt"
+bottom:
+  - label: Datenschutz
+    link: "/datenschutz"
+  - label: Seitenverzeichnis
+    link: "/sitemap.xml"
+  - label: Admin
+    link: "/admin"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -24,18 +24,27 @@
 		</div>
 	</div>
 	<div class="footer__bottom">
-		<a href="https://www.schweizermedien.ch/medienkompetenz/angebote-netzwerkpartner" class="footer__partner">
-			<img src="{{ .Site.Params.cloudinary_url }}/c_scale,q_auto:good,w_200/v1595591559/logos/sm_grey_sx76sk.png" alt="Schweizer Medien logo" class="footer__partner-logo" >
-			<div class="footer__partner-line"></div>
-			<ul class="footer__partner-list">
-				<li class="footer__partner-text">Offizieller</li>
-				<li class="footer__partner-text">Netzwerkpartner</li>
-				<li class="footer__partner-text">Verband</li>
+		<div class="footer__bottom-left">
+			<ul class="footer__column--normal footer__bottom-links">
+				{{ range .Site.Data.partials.footer.bottom}}
+					<li class="footer__bottom-item"><a href="{{ .link }}" class="footer__column-link">{{ .label }}</a></li>
+				{{ end }}
 			</ul>
-		</a>
+			<a href="https://www.schweizermedien.ch/medienkompetenz/angebote-netzwerkpartner" class="footer__partner">
+				<img src="{{ .Site.Params.cloudinary_url }}/c_scale,q_auto:good,w_200/v1595591559/logos/sm_grey_sx76sk.png" alt="Schweizer Medien logo" class="footer__partner-logo" >
+				<div class="footer__partner-line"></div>
+				<ul class="footer__partner-list">
+					<li class="footer__partner-text">Offizieller</li>
+					<li class="footer__partner-text">Netzwerkpartner</li>
+					<li class="footer__partner-text">Verband</li>
+				</ul>
+			</a>
+		</div>
 		<div class="footer__line"></div>
-		<div class="footer__social-group">
-			{{- partial "svgs/social_svgs.html" . -}}
+		<div class="footer__bottom-right">
+			<div class="footer__social-group">
+				{{- partial "svgs/social_svgs.html" . -}}
+			</div>
 		</div>
 	</div>
 </footer>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -40,7 +40,7 @@
 				</ul>
 			</a>
 		</div>
-		<div class="footer__line"></div>
+		<div class="footer__line-horizontal"></div>
 		<div class="footer__bottom-right">
 			<div class="footer__social-group">
 				{{- partial "svgs/social_svgs.html" . -}}


### PR DESCRIPTION
Cleaned up the footer by relocating the administrative and legal links to the bottom section of the footer, making the centre of the footer more uniform.

**Big screens:**
<img width="1680" alt="CleanShot 2020-11-09 at 17 28 50@2x" src="https://user-images.githubusercontent.com/16960228/98568500-71478380-22b1-11eb-9c9f-dee3f62476c0.png">

**Smaller screens:**
<img width="526" alt="CleanShot 2020-11-09 at 17 29 31@2x" src="https://user-images.githubusercontent.com/16960228/98568526-786e9180-22b1-11eb-9157-2631f4987d2f.png">
