### PR TITLE
Youtube video resize

### DIFF
--- a/.forestry/snippets/tweet.snippet
+++ b/.forestry/snippets/tweet.snippet
@@ -1,3 +1,3 @@
-{{< container-center >}}
+{{< tweet-container >}}
 	{{< tweet >}}
-{{< /container-center>}}
+{{< /tweet-container >}}

--- a/assets/sass/components/_tweet_container.scss
+++ b/assets/sass/components/_tweet_container.scss
@@ -1,0 +1,5 @@
+.tweet__container {
+	display: flex;
+	justify-content: center;
+	margin-bottom: $margin-s;
+}

--- a/assets/sass/layout/_print_format.scss
+++ b/assets/sass/layout/_print_format.scss
@@ -44,7 +44,7 @@
 		}
 
 		.single__content-video,
-		.container__center { display: none; }
+		.tweet__container { display: none; }
 	}
 
 	.single__content:after {

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -23,6 +23,7 @@
 @import "components/social_svgs";
 @import "components/support_us";
 @import "components/teiler";
+@import "components/tweet_container";
 @import "components/world_map";
 
 @import "layout/footer";

--- a/assets/sass/pages/_single.scss
+++ b/assets/sass/pages/_single.scss
@@ -72,6 +72,19 @@
 			display: flex;
 			align-self: center;
 		}
+
+		&-video {
+			display: flex;
+			justify-content: center;
+
+			iframe {
+				width: 60rem;
+				height: 40rem;
+				margin-bottom: 3rem;
+			}
+		}
+
+
 	}
 
 	&__comments {

--- a/assets/sass/pages/_single.scss
+++ b/assets/sass/pages/_single.scss
@@ -68,11 +68,6 @@
 
 		.arbeitsmaterial__link { color: $color-black; }
 
-		&-iframe {
-			display: flex;
-			align-self: center;
-		}
-
 		&-video {
 			display: flex;
 			justify-content: center;

--- a/assets/sass/pages/_single.scss
+++ b/assets/sass/pages/_single.scss
@@ -78,8 +78,6 @@
 				margin-bottom: 3rem;
 			}
 		}
-
-
 	}
 
 	&__comments {

--- a/content/sie-sie-sie-auch-me-too.md
+++ b/content/sie-sie-sie-auch-me-too.md
@@ -23,9 +23,9 @@ _Wenn ein Mensch einen anderen Menschen auf eine Art körperlich berührt, ohne 
 
 Diese zwei Worte sind die berühmtesten Worte auf sozialen Plattformen wie z.B Twitter. Diese Worte wurden so berühmt, weil im Oktober 2017 in der amerikanischen Zeitung «New York Times» ein Artikel über den 67 Jährigen erfolgreichen Filmproduzenten Harvey Weinstein erschien. Ihm wurde darin vorgeworfen, dass er mehrere Frauen {{< fremdwort id="sexuell genötigt" wort="sexuell genötigt" >}} und einige auch vergewaltigt haben soll.
 
-{{< container-center >}}
+{{< tweet-container >}}
 {{< tweet 919659438700670976 >}}
-{{< /container-center >}}
+{{< /tweet-container >}}
 
 {{< definition id="sexuell genötigt" wort="Sexuelle Nötigung" def="Sexuelle Nötigung bedeutet, dass sexuelle Handlungen gegen den Willen des Opfers gemacht werden. Vergewaltigung ist auch eine Art von sexueller Nötigung, bei der das Opfer nicht «nur» zu sexuellen Handlungen, sondern auch zu Sex gezwungen wird." >}}
 

--- a/layouts/shortcodes/tweet-container.html
+++ b/layouts/shortcodes/tweet-container.html
@@ -1,0 +1,1 @@
+<div class="tweet__container">{{ .Inner }}</div>


### PR DESCRIPTION
Having added a personal class to the youtube shortcode in PR #98 - all `iframe` styles were voided. This PR resolves this issue by adding height and width attributes the `.class iframe` element.

Furthermore, I created a new `tweet-container` shortcode that works in the exact same manner as the `container-center` shortcode. This solves the issue of being able to not display the tweet card when printing an article, without potentially ridding pertinent article components that might be using the `container-center` shortcode...in the future.  