### PR TITLE
Add custom 404 page

### DIFF
--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -30,6 +30,7 @@
 @import "layout/navbar";
 @import "layout/print_format";
 
+@import "pages/404";
 @import "pages/abonnemente";
 @import "pages/datenschutz";
 @import "pages/fokus_der_woche";

--- a/assets/sass/pages/_404.scss
+++ b/assets/sass/pages/_404.scss
@@ -1,0 +1,25 @@
+.fof {
+	@include container-main;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+
+	&__text {
+		font-family: $font-patrick, $font-fallback;
+
+		&--title {
+			font-weight: 700;
+			font-size: 10rem;
+
+			@include respond(phone-xl) { font-size: 6rem; }
+		}
+
+		&--caption {
+			font-size: 3.5rem;
+			text-align: center;
+			margin: 3rem 0;
+
+			@include respond(phone-xl) { font-size: 2.2rem; }
+		}
+	}
+}

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,0 +1,3 @@
+{{ define "main" }}
+
+{{ end }}

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,3 +1,10 @@
 {{ define "main" }}
-
+	<section class="404">
+		<div class="404__text 404__text--title">UPS!</div>
+		<img src="{{ $.Site.Params.cloudinary_url }}/c_scale,w_800/graphics/page-not-found_gfhkg9.png" alt="Page not found graphic" class="404__img">
+		<div class="404__text 404__text--caption">
+			Wir haben alle uns zur Verfügung stehenden Tools genutzt und konnten die
+			gesuchte Seite immer noch nicht finden.
+		</div>
+	</section>
 {{ end }}

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,10 +1,18 @@
 {{ define "main" }}
-	<section class="404">
-		<div class="404__text 404__text--title">UPS!</div>
-		<img src="{{ $.Site.Params.cloudinary_url }}/c_scale,w_800/graphics/page-not-found_gfhkg9.png" alt="Page not found graphic" class="404__img">
-		<div class="404__text 404__text--caption">
+	<section class="fof">
+		<div class="fof__text fof__text--title">UPS...</div>
+		<img srcset="{{ .Site.Params.cloudinary_url }}/c_scale,w_320/graphics/page-not-found_gfhkg9.png 320w,
+			{{ .Site.Params.cloudinary_url }}/c_scale,w_414/graphics/page-not-found_gfhkg9.png 414w,
+			{{ .Site.Params.cloudinary_url }}/c_scale,w_512/graphics/page-not-found_gfhkg9.png 512w,
+			{{ .Site.Params.cloudinary_url }}/c_scale,w_600/graphics/page-not-found_gfhkg9.png 600w"
+			sizes="(min-width: 800px) 800px, 100vw"
+			src="{{ .Site.Params.cloudinary_url }}/c_scale,w_800/graphics/page-not-found_gfhkg9.png"
+			alt="Page not found graphic"
+			class="fof__img">
+		<div class="fof__text fof__text--caption">
 			Wir haben alle uns zur Verfügung stehenden Tools genutzt und konnten die
 			gesuchte Seite immer noch nicht finden.
 		</div>
+		<a href="/" class="btn btn--primary">Bringen Sie mich zurück nach Hause</a>
 	</section>
 {{ end }}


### PR DESCRIPTION
Currently, when a user travels to a page that doesn't exist on Chinderzytig, they are met with a generic 404 page error from Netlify. This PR changes that by displaying our own custom branded 404 page:

![CleanShot 2020-11-12 at 17 48 48@2x](https://user-images.githubusercontent.com/16960228/98969661-5d00c200-250f-11eb-8953-371b389785ef.png)
