### PR TITLE
Fix Kategorien and Markierungen order

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -14,7 +14,7 @@
 			<section class="list">
 				<h3 class="heading heading--list">{{ .Title }} Markierungen</h3>
 				<div class="list__markers">
-					{{ range $tags }}
+					{{ range $tags.ByTitle }}
 					<a href="{{ .Permalink }}" class="marker marker--list">{{ .LinkTitle }}</a>
 					{{ end }}
 				</div>


### PR DESCRIPTION
This PR fixes how categories and tags are displayed by listing them in alphabetical order by title. 