### PR TITLE
Updated Migros logo

### DIFF
--- a/data/pages/verein.yaml
+++ b/data/pages/verein.yaml
@@ -50,18 +50,18 @@ btns:
     - text: Kontaktiere Uns
 
 companies:
-- website: "https://www.migros.ch/de/genossenschaften.html"
+- website: "https://www.migros-kulturprozent.ch/"
   logo:
-    - img: "migros_swxvzo.png"
+    - img: "schwarzweiss_d_bmyctr.eps"
       desc: Migros logo
-- website: "https://www.phbern.ch/"
-  logo:
-    - img: "phbern_black_e5tq45.png"
-      desc: PHBern logo
 - website: "https://stiftungschweiz.ch/"
   logo:
     - img: "stiftun_schweiz_x8sv4n.png"
       desc: Stiftung Schweiz logo
+- website: "https://www.phbern.ch/"
+  logo:
+    - img: "phbern_black_e5tq45.png"
+      desc: PHBern logo
 - website: "https://www.bildungbern.ch/"
   logo:
     - img: "bildung-bern_yqpjs1.png"


### PR DESCRIPTION
Updated the Migros logo on the Verein page to reflect the entity of Migros that provided the donation:

<img width="1142" alt="CleanShot 2020-12-21 at 20 40 25@2x" src="https://user-images.githubusercontent.com/16960228/102815560-ce644800-43cc-11eb-8da3-c89b80962ce0.png">
