### PR TITLE
Coronavirus tag fix/section display

### DIFF
--- a/assets/sass/pages/_index.scss
+++ b/assets/sass/pages/_index.scss
@@ -11,8 +11,8 @@
 }
 
 .fdw__cta {
-	border: 1rem solid $chinder-platinum;
-	margin-bottom: 0;
+	@include cta-color($cta-seashell);
+	margin-bottom: 3rem;
 	padding: 4rem 0;
 
 	&-container {
@@ -30,5 +30,3 @@
 		@include respond(phone-xl) { margin-top: 3rem; }
 	}
 }
-
-.special__cta { @include cta-color($cta-seashell); }

--- a/content/coronavirus.md
+++ b/content/coronavirus.md
@@ -1,18 +1,17 @@
 ---
 title: Ein Virus versetzt die Welt in Aufruhr
 slug: coronavirus
-description: 
+description:
 date: 2020-02-23T16:54:31.000+02:00
 author: Lars Ziörjen
 hero_img: coronavirus_rgdsvi.jpg
-img_description: 
+img_description:
 img_photographer: Waldemar Brandt
 img_src: https://unsplash.com/@waldemarbrandt67w?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText
 kategorien:
 - Welt
 markierungen:
 - Gesundheit
-- COVID19
 fdw: false
 paid: false
 artikel: true

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -39,7 +39,7 @@
 			</a>
 			{{ $fdwArtikel := where .Site.Pages ".Params.fdw" true }}
 			{{ range first 1 $fdwArtikel.ByDate.Reverse }}
-				<a href="{{.RelPermalink}}" class="card card--grey fdw__cta-card">
+				<a href="{{.RelPermalink}}" class="card card--white fdw__cta-card">
 					<div class="card__img-container">
 						<img srcset="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }},
 							{{ .Site.Params.cloudinary_url }}/f_auto,h_180,w_270,q_auto:good/{{ .Params.hero_img }} 1100w,

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -8,7 +8,7 @@
 			<h2 class="heading heading__tertiary">Neuste Artikel</h2>
 			<div class="card__container">
 				{{ $artikel := where (where .Site.Pages ".Params.artikel" true) ".Params.fdw" false }}
-				{{ range first 6 $artikel.ByDate.Reverse }}
+				{{ range first 9 $artikel.ByDate.Reverse }}
 				<a href="{{.RelPermalink}}" class="card card--white">
 					<div class="card__img-container">
 						<img srcset="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }},

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -58,33 +58,5 @@
 		</div>
 	</section>
 
-	<section class="special__cta">
-		<div class="card__list">
-			<h2 class="heading heading__tertiary">Coronavirus</h2>
-			<div class="card__container">
-				{{ range first 3 .Site.Taxonomies.markierungen.covid19 }}
-					<a href="{{.RelPermalink}}" class="card card--white">
-						<div class="card__img-container">
-							<img srcset="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }},
-								{{ .Site.Params.cloudinary_url }}/f_auto,h_180,w_270,q_auto:good/{{ .Params.hero_img }} 1100w,
-								{{ .Site.Params.cloudinary_url }}/f_auto,h_167,w_250,q_auto:good/{{ .Params.hero_img }} 900w"
-								src="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }}"
-								alt="{{ .Params.img_description }}"
-								class="card__img"
-							/>
-						</div>
-						<div class="card__content">
-							<h3 class="card__content-title">{{ .Title }}</h3>
-							<div class="card__content-date">{{ .Date.Format .Site.Params.DateForm }}</div>
-						</div>
-					</a>
-				{{ end }}
-			</div>
-			<div class="btn__container">
-				<a href="/markierungen/covid19" class="btn btn--primary">Mehr Artikel</a>
-			</div>
-		</div>
-	</section>
-
 	{{- partial "support_us.html" . -}}
 {{end}}


### PR DESCRIPTION
Removed the Coronavirus section on the index page as a result of the consolidated categories and tags. As well, I removed the COVID-19 tag from a stubborn article that refused to let go.

Other updates include style changes to the FdW CTA on the index page, as well as extending the amount of new articles being displayed from 6 to nine.