### PR TITLE
Add new company support logos

### DIFF
--- a/data/pages/verein.yaml
+++ b/data/pages/verein.yaml
@@ -98,3 +98,11 @@ companies:
   logo:
     - img: "poly_rnmcnm.png"
       desc: Polygon Schule logo
+- website: "http://kit-initiative.de/"
+  logo:
+    - img: "KIT-Logo_xbzlwp.png"
+      desc: KIT-Initiative logo
+- website: "http://www.schule-kihe.ch/"
+  logo:
+    - img: "schule-kh_bzefc6.png"
+      desc: Schule Kirchlindach Herrenschwanden logo


### PR DESCRIPTION
Added two new company logos to the Verein page: KIT-initiative and Schule Kirchlindach Herrenschwanden.
<img width="1087" alt="CleanShot 2021-02-01 at 23 03 48@2x" src="https://user-images.githubusercontent.com/16960228/106523750-df32ce00-64e1-11eb-86bf-292e0c35a0ec.png">
