### PR TITLE
Impfstoffe index graphic

### DIFF
--- a/assets/sass/components/_impfstoffe.scss
+++ b/assets/sass/components/_impfstoffe.scss
@@ -20,6 +20,7 @@
 	}
 
 	&__item {
+		margin-bottom: 3rem;
 
 		@include respond(tab-port-sm) {
 

--- a/assets/sass/components/_impfstoffe.scss
+++ b/assets/sass/components/_impfstoffe.scss
@@ -1,8 +1,12 @@
 .impfstoffe {
 	margin: 3rem 0;
 
-	&__intro-text {
-		text-align: justify;
+	&__intro-text { text-align: justify; }
+
+	&__article-link {
+
+		&:link,
+		&:visited { color: $chinder-verdigris; }
 	}
 
 	&__main {

--- a/assets/sass/components/_impfstoffe.scss
+++ b/assets/sass/components/_impfstoffe.scss
@@ -1,6 +1,10 @@
 .impfstoffe {
 	margin: 3rem 0;
 
+	&__intro-text {
+		text-align: justify;
+	}
+
 	&__main {
 		display: flex;
 		justify-content: space-around;
@@ -9,7 +13,11 @@
 		@include respond(tab-port-sm) { flex-direction: column-reverse; }
 	}
 
-	&__stats {
+	&__stats,
+	&__stats-sc {
+		background-color: $chinder-cultured;
+		list-style: none;
+		padding: 3rem;
 
 		@include respond(tab-port-sm) {
 			margin-top: 3rem;
@@ -19,8 +27,11 @@
 		}
 	}
 
+	&__stats-sc { padding-bottom: 0; }
+
 	&__item {
-		margin-bottom: 3rem;
+
+		&:not(:last-child) { margin-bottom: 3rem; }
 
 		@include respond(tab-port-sm) {
 
@@ -40,9 +51,12 @@
 
 	&__source {
 		font-size: 1.3rem;
-		margin-left: 5rem;
+		margin-left: 2rem;
 
-		@include respond(tab-port-sm) { margin-left: 0; }
+		@include respond(tab-port-sm) {
+			margin-left: 0;
+			margin-top: 2rem;
+		}
 	}
 }
 

--- a/assets/sass/components/_impfstoffe.scss
+++ b/assets/sass/components/_impfstoffe.scss
@@ -40,7 +40,7 @@
 
 	&__source {
 		font-size: 1.3rem;
-		margin-left: 7rem;
+		margin-left: 5rem;
 
 		@include respond(tab-port-sm) { margin-left: 0; }
 	}

--- a/assets/sass/pages/_index.scss
+++ b/assets/sass/pages/_index.scss
@@ -7,7 +7,7 @@
 
 .new__cta {
 	@include cta-color($cta-azure);
-	margin-bottom: 0;
+	margin-bottom: 3rem;
 }
 
 .fdw__cta {

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -36,11 +36,11 @@
 		<div class="impfstoffe__container card__list">
 			<h2 class="heading heading__tertiary">Coronavirus Impfstoffe</h2>
 			<p class="impfstoffe__intro-text">
-				Hast du Fragen über Impfstoffe? Dann fängst mit unseren Artikel an:
-				<a href="https://www.chinderzytig.ch/heile-heile-sage-oder-jetzt-wird-geimpft/">
+				Testen, Mutanten, Viren, Impfen? Corona, Covid, B.1.1.7? Hier behältst
+				du den Überblick:
+				<a href="https://www.chinderzytig.ch/heile-heile-sage-oder-jetzt-wird-geimpft/" class="impfstoffe__article-link">
 					Heile, heile, säge… oder: jetzt wird geimpft!
-				</a>. Wie weit die Schweiz im Impfplan ist, zeigen wir euch nun mit der
-				regelmässig aktualisierten Schweizerkarte; damit ihr im Bild seid!
+				</a>
 			</p>
 
 			{{ partial "impfstoffe.html" (dict "gelieferte" "696 700" "verabreichte" "413 698" "geimpfte" "4,79%" "offleft" "4.79%" "offright" "4.81%") }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -35,6 +35,13 @@
 	<section class="impfstoffe__cta">
 		<div class="impfstoffe__container card__list">
 			<h2 class="heading heading__tertiary">Coronavirus Impfstoffe</h2>
+			<p class="impfstoffe__intro-text">
+				Hast du Fragen über Impfstoffe? Dann fängst mit unseren Artikel an:
+				<a href="https://www.chinderzytig.ch/heile-heile-sage-oder-jetzt-wird-geimpft/">
+					Heile, heile, säge… oder: jetzt wird geimpft!
+				</a>. Wie weit die Schweiz im Impfplan ist, zeigen wir euch nun mit der
+				regelmässig aktualisierten Schweizerkarte; damit ihr im Bild seid!
+			</p>
 
 			{{ partial "impfstoffe.html" (dict "gelieferte" "696 700" "verabreichte" "413 698" "geimpfte" "4,79%" "offleft" "4.79%" "offright" "4.81%") }}
 		</div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -32,6 +32,14 @@
 		</div>
 	</section>
 
+	<section class="impfstoffe__cta">
+		<div class="impfstoffe__container card__list">
+			<h2 class="heading heading__tertiary">Coronavirus Impfstoffe</h2>
+
+			{{ partial "impfstoffe.html" (dict "gelieferte" "696 700" "verabreichte" "413 698" "geimpfte" "4,79%" "offleft" "4.79%" "offright" "4.81%") }}
+		</div>
+	</section>
+
 	<section class="fdw__cta">
 		<div class="card__list fdw__cta-container">
 			<a href="/fokus-der-woche" class="fdw__cta-link">

--- a/layouts/partials/impfstoffe.html
+++ b/layouts/partials/impfstoffe.html
@@ -1,0 +1,24 @@
+<div class="impfstoffe">
+	<div class="impfstoffe__main">
+		<ul class="impfstoffe__stats">
+			<li class="impfstoffe__item">Total gelieferte Dosen:<span class="impfstoffe__num">{{ .gelieferte }}</span></li>
+			<li class="impfstoffe__item">Total verabreichte Dosen:<span class="impfstoffe__num">{{ .verabreichte }}</span></li>
+			<li class="impfstoffe__item">Einfach geimpfte Personen:<span class="impfstoffe__num">{{ .geimpfte }}</span></li>
+		</ul>
+		<svg viewBox="0 0 581 373" xmlns="http://www.w3.org/2000/svg">
+			<defs>
+				<linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="0%">
+					<stop offset="{{ .offleft }}" style="stop-color:rgb(218,41,28);stop-opacity:1" />
+					<stop offset="{{ .offright }}" style="stop-color:rgb(255,255,255);stop-opacity:1" />
+				</linearGradient>
+			</defs>
+	    <g transform="matrix(1,0,0,1,-21.5,-46.5)">
+	        <g>
+	            <path d="M340,90L324,88L318,81L306,82L290,93L273,92L270,87L260,87L249,95L235,93L240,86L235,84L218,94L211,108L207,117L184,118L180,108L157,106L153,111L141,132L163,135L124,178L104,202L84,214L84,240L80,248L45,277L42,293L40,310L47,319L41,339L23,349L43,362L64,342L57,324L77,310L114,303L129,318L133,338L128,361L140,378L158,389L162,404L188,407L209,397L230,388L261,402L286,374L302,357L298,334L308,331L328,304L341,302L346,346L364,364L391,371L382,389L399,401L400,416L416,418L423,403L411,388L423,374L430,357L443,342L449,322L443,298L456,291L468,291L469,318L486,332L505,331L513,322L534,318L540,331L544,346L561,342L555,326L560,313L557,305L546,298L553,274L569,270L573,284L599,286L601,269L587,262L596,246L594,232L598,213L586,200L576,214L558,226L527,216L520,197L476,191L478,180L475,161L496,119L485,105L481,98L444,76L401,77L378,60L360,48L337,65L358,79L340,90Z" style="fill:url(#grad1);stroke:black;stroke-width:3px;"/>
+	            <path d="M479.669,151.661L486,155L482,161L487,164L489,172L487,179L490,184L494,194" style="fill:none;stroke:black;stroke-width:3px;"/>
+	        </g>
+	    </g>
+		</svg>
+	</div>
+	<div class="impfstoffe__source">Quelle: <a href="https://www.covid19.admin.ch/en/epidemiologic/vacc-doses" target="_blank" class="Impfstoffe__link">FOPH</a></div>
+</div>

--- a/layouts/shortcodes/impfstoffe.html
+++ b/layouts/shortcodes/impfstoffe.html
@@ -1,6 +1,6 @@
 <div class="impfstoffe">
 	<div class="impfstoffe__main">
-		<ul class="impfstoffe__stats">
+		<ul class="impfstoffe__stats-sc">
 			<li class="impfstoffe__item">Total gelieferte Dosen:<span class="impfstoffe__num">{{ .Get "gelieferte" }}</span></li>
 			<li class="impfstoffe__item">Total verabreichte Dosen:<span class="impfstoffe__num">{{ .Get "verabreichte" }}</span></li>
 			<li class="impfstoffe__item">Einfach geimpfte Personen:<span class="impfstoffe__num">{{ .Get "geimpfte" }}</span></li>


### PR DESCRIPTION
Partial-ized the Impfstoffe shortcode for use as a cta on the index page:

<img width="1157" alt="CleanShot 2021-02-11 at 13 45 09@2x" src="https://user-images.githubusercontent.com/16960228/107638107-6fee7400-6c6f-11eb-8aa7-c0b1654a6527.png">
