### PR TITLE
Bildung Schweiz Artikel

### DIFF
--- a/data/pages/verein.yaml
+++ b/data/pages/verein.yaml
@@ -1,4 +1,11 @@
 media:
+- url: "https://res.cloudinary.com/chinderzytig/image/upload/v1621257734/bildung_schweiz_artikel_tzusl4.pdf"
+  logo:
+    - img: "lch_cgs75m.png"
+      description: "Dachverband Lehrerinnen und Lehrer Schweiz logo"
+  content:
+    - title: "BILDUNG SCHWEIZ - Chinderzytig: Packend und verständlich geschrieben"
+      date: "01.05.2021"
 - url: "https://res.cloudinary.com/chinderzytig/image/upload/v1604329083/lindacher-okt-2020_euil5y.pdf"
   logo:
     - img: "lindacher-nachrichten_xxv5jv.png"


### PR DESCRIPTION
As requested, added the [Photos of the] Bildung Schweiz article to the Medien section on the verein page. Will update this with the actual pdf link to the article once LCH publishes it online.

![CleanShot 2021-05-17 at 15 56 21@2x](https://user-images.githubusercontent.com/16960228/118500966-8bfb2900-b728-11eb-9b90-9c75fff5114a.png)

<img width="1665" alt="CleanShot 2021-05-17 at 15 56 53@2x" src="https://user-images.githubusercontent.com/16960228/118500983-91587380-b728-11eb-80e3-a18d559c3b34.png">

