### PR TITLE
Visible Learning page updates

### DIFF
--- a/assets/sass/components/_btn.scss
+++ b/assets/sass/components/_btn.scss
@@ -66,11 +66,33 @@
 
 	&--kontakt,
 	&--form,
-	&--pricing {
+	&--pricing,
+	&--visible {
 		font-family: 'Lato', sans-serif;
 		font-weight: 300;
 		text-align: center;
 		box-sizing: content-box;
+	}
+
+	&--visible {
+		display: flex;
+		justify-content: center;
+		margin-bottom: 6rem;
+
+		&:link,
+		&:visited {
+			color: $color-white;
+			background-color: $chinder-verdigris;
+			border: 2px solid $chinder-celadon;
+			text-decoration: none;
+		}
+
+		&:hover,
+		&:active {
+			color: $color-black;
+			background-color: $color-white;
+			border-color: $color-black;
+		}
 	}
 
 	&--verein {

--- a/data/pages/visible.yaml
+++ b/data/pages/visible.yaml
@@ -17,7 +17,7 @@ pricing:
       - inclusion: "Visible Learning Prozess als Basis für die Auswertung von Kompetenzen im Unterricht"
       - inclusion: "Vorlagen Lernbericht"
       - inclusion: "Online Einführung (Video)"
-    number: "CHF 500.-"
+    number: "CHF 570.-"
     target: "pro Klasse und Jahr"
   - name: "mirroco-Chinderzytig professional Schulen"
     type: "Für die Gestaltung und Auswertung eines individualisierten Unterrichts"

--- a/layouts/_default/visible-learning.html
+++ b/layouts/_default/visible-learning.html
@@ -93,7 +93,7 @@
 			</p>
 		</section>
 
-		<h2 class="heading heading__content--secondary">Bist du Interessiert?</h2>
+		<h2 class="heading heading__content--secondary">Gibt es noch Fragen? Nimm Kontakt auf</h2>
 		<p class="visible__text">
 			Wir erzählen gerne mehr über Testabos und Visible Learning! Ausfüllen und
 			wir nehmen rasch Kontakt auf.

--- a/layouts/_default/visible-learning.html
+++ b/layouts/_default/visible-learning.html
@@ -97,6 +97,8 @@
 			</p>
 		</section>
 
+		<a href="https://www.mirroco.ch/register" target="_blank" class="btn btn--visible">Registrieren/zum Testabo</a>
+
 		<h2 class="heading heading__content--secondary">Gibt es noch Fragen? Nimm Kontakt auf</h2>
 		<p class="visible__text">
 			Wir erzählen gerne mehr über Testabos und Visible Learning! Ausfüllen und

--- a/layouts/_default/visible-learning.html
+++ b/layouts/_default/visible-learning.html
@@ -15,9 +15,13 @@
 			Individuelle Lernbegleitung ist der Schlüssel für stärkende Bildung.
 			Visible Learning von mirroco ermöglicht die Kompetenzentwicklung der
 			Lernenden im Hinblick auf den Lehrplan 21 sichtbar zu machen und mit
-			Weitsicht zu begleiten. Visible Learning Prozess in 5 Schritten bist
-			Du bereits am Ziel
+			Weitsicht zu begleiten.
 		</p>
+
+		<h2 class="heading heading__content--secondary">
+			Visible Learning Prozess - In 5 Schritten bist Du bereits am Ziel
+		</h2>
+
 		<div class="visible__img-container">
 			<img srcset="{{ .Site.Params.cloudinary_url }}/c_scale,q_auto:best,w_320/graphics/visible-learning-schritte_oa0oh2.png 320w,
 			{{ .Site.Params.cloudinary_url }}/c_scale,q_auto:best,w_414/graphics/visible-learning-schritte_oa0oh2.png 414w,

--- a/layouts/_default/visible-learning.html
+++ b/layouts/_default/visible-learning.html
@@ -90,10 +90,10 @@
 			</div>
 			<p class="pricing__fineprint">
 				Sämtliche Chinderzytig-Inhalte sind verfügbar (primär Fachbereich NMG
-				und Deutsch) und fürs Visible Learning nach LP21 aufbereitet. Preise für
-				Schulen beinhalten CHF 300.- Hazu Lizenz. Preise verstehen sich exkl.
-				MwSt. Bei mirroco-chinderzytig professional ab 15 Klassen Preis auf
-				Anfrage.
+				und Deutsch) und fürs Visible Learning nach LP21 aufbereitet. Preise
+				für Schulen beinhalten CHF 300.- Hazu Lizenz sowie CHF 500.- mirroco-Tools.
+				Preise verstehen sich exkl. MwSt. Bei mirroco-chinderzytig professional
+				ab 15 Klassen Preis auf Anfrage.
 			</p>
 		</section>
 


### PR DESCRIPTION
Incorporated the follow requests from the team:

<img width="765" alt="CleanShot 2021-07-26 at 19 07 29@2x" src="https://user-images.githubusercontent.com/16960228/127030147-a2ead72a-ccd3-4776-909d-7aa53d25b8dd.png">
