### PR TITLE
Polygon Schule logo removal

### DIFF
--- a/data/pages/verein.yaml
+++ b/data/pages/verein.yaml
@@ -105,10 +105,6 @@ companies:
   logo:
     - img: "heavyfeather_czmc34.png"
       desc: Heavyfeather logo
-- website: "https://www.polygon-schule.ch/"
-  logo:
-    - img: "poly_rnmcnm.png"
-      desc: Polygon Schule logo
 - website: "http://kit-initiative.de/"
   logo:
     - img: "KIT-Logo_xbzlwp.png"


### PR DESCRIPTION
Removed Polygon Schule logo from the Verein page due to political conflicts surround this school and Non-profit organisations.

![CleanShot 2021-08-19 at 11 38 50@2x](https://user-images.githubusercontent.com/16960228/130046409-2fac143f-cf88-4939-a501-50b482d6b047.png)
