### PR TITLE
Create Simple image snippet

### DIFF
--- a/.forestry/snippets/simple-image.snippet
+++ b/.forestry/snippets/simple-image.snippet
@@ -1,0 +1,1 @@
+{{< image img="Enter file with ext. here" desc="Enter photo description here" >}}

--- a/layouts/shortcodes/simple-image.html
+++ b/layouts/shortcodes/simple-image.html
@@ -1,0 +1,8 @@
+<figure class="image">
+	<img srcset="{{ .Site.Params.cloudinary_url }}/f_auto,q_auto:good,w_320/{{ .Get `img` }} 320w,
+		{{ .Site.Params.cloudinary_url }}/f_auto,q_auto:good,w_414/{{ .Get `img` }} 414w"
+		sizes="(min-width: 600px) 600px, 100vw"
+		src="{{ .Site.Params.cloudinary_url }}/f_auto,q_auto:good,w_600/{{ .Get `img` }}"
+		alt="{{ .Get `desc` }}"
+		class="image__img"/>
+</figure>


### PR DESCRIPTION
Created a snippet for forestry that will allow admins to insert photos without captions. This is required for the creation of the Oscar quiz article.

I decided to create a whole new snippet rather than utilise the current image snippet, because its future within its current context is questionable.