### PR TITLE
create snippet for custom title

### DIFF
--- a/.forestry/snippets/generic-group.snippet
+++ b/.forestry/snippets/generic-group.snippet
@@ -1,0 +1,5 @@
+{{< teiler >}}
+
+{{< generic-group title="enter title for section here" >}}
+	{{< arbeitsmaterial >}}
+{{< /generic-group >}}

--- a/layouts/shortcodes/generic-group.html
+++ b/layouts/shortcodes/generic-group.html
@@ -1,0 +1,6 @@
+<div class="arbeitsmaterial-sc-group">
+	<h3 class="arbeitsmaterial-sc__heading">{{ .Get "title" }}</h3>
+	<div class="arbeitsmaterial-sc__container">
+		{{ .Inner }}
+	</div>
+</div>


### PR DESCRIPTION
Created a snippet that will allow admins to create custom titles for the arbeitsmaterial section. This is in response to the Oscars quiz article the provides an answer key in the arbeitsmaterial section.