### PR TITLE
Burgergemeinde logo Bern

### DIFF
--- a/data/pages/verein.yaml
+++ b/data/pages/verein.yaml
@@ -160,3 +160,7 @@ companies:
   logo:
     - img: "Arag_dgug2o.png"
       desc: ARAG AG Gebäudereinigung logo
+- website: "https://www.bgbern.ch/"
+  logo:
+    - img: "BGB_Logo_x6abss.png"
+      desc: Burgergemeinde Bern logo


### PR DESCRIPTION
Added Burgergemeinde logo to verein page:

<img width="1265" alt="CleanShot 2023-03-14 at 07 55 37@2x" src="https://user-images.githubusercontent.com/16960228/224919954-80115ff3-d999-4c65-90e6-b791d7109a18.png">
