### PR TITLE
Fix main element margins 

### DIFF
--- a/assets/sass/base/_base.scss
+++ b/assets/sass/base/_base.scss
@@ -35,6 +35,8 @@ main {
 	margin-top: 13rem;
 
 	@include respond(tab-land) { padding: 0 3rem; }
+
+	@include respond(phone-lg) { margin-top: 16rem; }
 }
 
 section { padding: 3rem; }

--- a/assets/sass/base/_base.scss
+++ b/assets/sass/base/_base.scss
@@ -31,9 +31,8 @@ html, body {
 main {
 	background-color: $white;
 	max-width: 1100px;
-	margin-left: auto;
-	margin-right: auto;
-	padding: 20rem 0 1rem 0;
+	margin: 0 auto;
+	margin-top: 13rem;
 
 	@include respond(tab-land) { padding: 0 3rem; }
 }

--- a/assets/sass/base/_base.scss
+++ b/assets/sass/base/_base.scss
@@ -36,7 +36,13 @@ main {
 
 	@include respond(tab-land) { padding: 0 3rem; }
 
+	@include respond(tab-port-sm) { padding: 0; }
+
 	@include respond(phone-lg) { margin-top: 16rem; }
 }
 
-section { padding: 3rem; }
+section {
+	padding: 3rem;
+
+	&.ukraine { @include respond(tab-port-sm) { padding: 0; } }
+}

--- a/assets/sass/components/_snipcart.scss
+++ b/assets/sass/components/_snipcart.scss
@@ -1,7 +1,7 @@
 .snipcart {
 	display: flex;
 	justify-content: flex-end;
-	padding-right: 3rem;
+	padding: 3rem 3rem 0 0;
 
 	&-modal__container { z-index: 3000; }
 

--- a/assets/sass/pages/_fokus_der_woche.scss
+++ b/assets/sass/pages/_fokus_der_woche.scss
@@ -2,9 +2,6 @@
 
 	&__intro {
 		@include cta-color($cta-seashell);
-		margin-top: -6rem;
-
-		@include respond(tab-port-sm) { margin-top: -3rem;}
 
 		&-container {
 			display: flex;

--- a/assets/sass/pages/_index.scss
+++ b/assets/sass/pages/_index.scss
@@ -1,8 +1,7 @@
-.map {
-	margin-top: -5rem;
-
-	@include respond(tab-port-sm) { margin-top: 0; }
-}
+// .map {
+//
+// 	@include respond(tab-port-sm) { margin-top: 0; }
+// }
 
 .new__cta {
 	@include cta-color($cta-azure);

--- a/assets/sass/pages/_index.scss
+++ b/assets/sass/pages/_index.scss
@@ -1,8 +1,3 @@
-// .map {
-//
-// 	@include respond(tab-port-sm) { margin-top: 0; }
-// }
-
 .new__cta {
 	@include cta-color($cta-azure);
 	margin-bottom: 3rem;

--- a/assets/sass/pages/_verein.scss
+++ b/assets/sass/pages/_verein.scss
@@ -61,6 +61,8 @@
 		@include cta-color($chinder-cultured);
 		margin-bottom: 0;
 
+		&-container { padding: 0 3rem; }
+
 		&-logos {
 			display: flex;
 			flex-wrap: wrap;

--- a/assets/sass/pages/_visible-learning.scss
+++ b/assets/sass/pages/_visible-learning.scss
@@ -1,5 +1,4 @@
 .visible {
-	margin-bottom: $margin-m;
 
 	&__text {
 		text-align: justify;


### PR DESCRIPTION
This PR fixes margin issues with the ```main``` element on smaller screens, shifting the uppermost content on all pages so that they are no longer cutoff by the navbar.

![CleanShot 2023-07-14 at 15 20 11@2x](https://github.com/Chinderzytig/chinderzytig-website/assets/16960228/c70032cf-86bb-47f2-8326-ac2a3f8b2d6b)
