### PR TITLE
Upgrade analytics to Google Analytics 4 (GA4)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 baseURL = "https://www.chinderzytig.ch"
-googleAnalytics = "UA-151249702-3"
+googleAnalytics = "G-364713773"
 languageCode = "de"
 title = "Die Zeitung für Kinder und Jugendliche"
 [params]


### PR DESCRIPTION
On July 1, 2023, Google Universal Analytics (UA) was deprecated with the release of Google Analytics 4. This PR updates the Google Analytics ID number in the config file with the migrated analytics profile in the Chinderzytig Google account.