### PR TITLE
Homepage reorder

### DIFF
--- a/content/Der-Kampf-um-die-Wahl.md
+++ b/content/Der-Kampf-um-die-Wahl.md
@@ -1,0 +1,38 @@
++++
+arbeitsmaterial = ""
+artikel = true
+author = "Carla, Wohler"
+cc_licence = ""
+cc_src = ""
+date = 2023-10-04T01:00:00Z
+description = ""
+fdw = true
+hero_img = "/Der_Kampf_um_die_Wahl_gvjykk.jpg"
+img_description = "Wahlplakate von Maja Riniker, Thierry Burkhart, Lukas Huber und Christoph Riner, Kandidaten der Staenderats- und Nationalratswahlen, fotografiert am Montag, 2. Oktober 2023 in Bellikon."
+img_photographer = "KEYSTONE"
+img_src = ""
+kategorien = []
+kfk = false
+markierungen = []
+paid = false
+slug = ""
+title = "Der Kampf um die Wahl"
++++
+
+_Im letzten Fokus der Woche wurde die Neuwahl des Schweizer Parlaments bereits angekündigt. In diesem Fokus der Woche liegt der Fokus jedoch nicht auf den Wahlobjekten National- und Ständerat, sondern auf den Wahlinstrumenten._
+
+Alle vier Jahre können sich alle stimmberechtigten Schweizer*innen zur
+Wahl in die eidgenössische Bundesversammlung stellen. 18 Jahre und der Schweizer Pass sind die einzigen Vorgaben für eine Kandidatur für das schweizer Parlament. Mitglieder, die bereits im National- oder Ständerat waren, dürfen sich zudem zur Wiederwahl stellen. Für die Stimmbürger/*innen gilt das gleiche – dazu kommt aber, dass alle Stimmberechtigten nur innerhalb ihrer Kantone wählen. Stimmbürger/*innen des Kantons Bern wählen daher nur Kandidierende aus dem Kanton Bern usw.
+Doch was heisst eigentlich wählen? Wenn ich wähle, dann gebe ich einem Kandidaten oder einer Kandidatin eine Stimme. Das heisst, ich entscheide mich, jemandem meine Stimme zu geben. Diese Stimme geht dann an die entsprechende Kandidatin oder an den entsprechenden Kandidaten.
+
+### Die Kandidatur und der Wahlkampf
+
+Es sind 200 Mitglieder, die in den Nationalrat (neu-)gewählt werden. Dazu sind es 46 Mitglieder, die in den Ständerat (wieder-)gewählt werden. Bei 5000 Kandidierenden sind es daher wenige, die für die nationale Bundesversammlung in Frage kommen. Die einzelnen Kandidierenden müssen sich daher gut überlegen, mit welchen Argumenten sie die Stimmbürger/*innen von sich überzeugen wollen. Und genau dort kommt das Wort „Wahlkampf“ ins Spiel. Die einzelnen Kandidierenden kämpfen sozusagen, für die Wahl. Dazu machen sie Wahlplakate, die auf Wiesen, in den Dörfern und Städten, beispielsweise auch auf Bahnhöfen, platziert werden. Eine weitere Möglichkeit, auf sich aufmerksam zu machen sind die sozialen Medien und Berichte in Zeitungen oder im Fernsehen. Erst so erhalten die Stimmbürger/*innen auch einen Überblick über die Anzahl der Kandidierenden und deren politischen Ideen. Dabei helfen aber auch die unterschiedlichen Parteien, indem sie auf ihre Listen hinweisen, auf denen die Kandidierenden ihrer Parteien stehen.
+
+Diese Listen erhalten dann alle Stimmbürger/*innen. Und jede stimmberechtigte Person kann dann entsprechend die Anzahl Nationalrat/*innen für ihren Kanton wählen. Dazu wählt sie auch noch zwei Ständerate/*innen, mit Ausnahme von Appenzell-Ausserrhoden und Innerrhoden sowie Obwalden und Nidwalden, die nur ein*e Ständerat/*in wählen. Welches am Schluss die 246 Kandidierenden sind, welche in die Bundesversammlung gewählt worden sind, wird sich am 22. Oktober zeigen.
+
+### Nun bist du dran
+
+Wer darf in der Schweiz die Mitglieder der nationalen Bundesversammlung wählen? Weshalb sind es 46 Mitglieder, die in den Ständerat (wieder-)gewählt werden können? Könntest du dir vorstellen, selbst einmal für das Schweizer Parlament zu kandidieren?
+
+Sprich darüber – und melde dich doch auch bei uns. Entweder mit einem Kommentar auf Facebook oder durch unser [Kontaktformular](https://www.chinderzytig.ch/kontakt/). Wir freuen uns auf Rückmeldungen.

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,29 @@
 {{define "main"}}
-	<section class="map">
-			{{- partial "world_map.html" . -}}
-	</section>
+<section class="fdw__cta">
+	<div class="card__list fdw__cta-container">
+		<a href="/fokus-der-woche" class="fdw__cta-link">
+			{{- partial "svgs/fdw_svg.html" . -}}
+		</a>
+		{{ $fdwArtikel := where .Site.Pages ".Params.fdw" true }}
+		{{ range first 1 $fdwArtikel.ByDate.Reverse }}
+			<a href="{{.RelPermalink}}" class="card card--grey fdw__cta-card">
+				<div class="card__img-container">
+					<img srcset="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }},
+						{{ .Site.Params.cloudinary_url }}/f_auto,h_180,w_270,q_auto:good/{{ .Params.hero_img }} 1100w,
+						{{ .Site.Params.cloudinary_url }}/f_auto,h_167,w_250,q_auto:good/{{ .Params.hero_img }} 900w"
+						src="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }}"
+						alt="{{ .Params.img_description }}"
+						class="card__img"
+					/>
+				</div>
+				<div class="card__content">
+					<h3 class="card__content-title">{{ .Title }}</h3>
+					<div class="card__content-date">{{ .Date.Format .Site.Params.DateForm }}</div>
+				</div>
+			</a>
+		{{ end }}
+	</div>
+</section>
 
 	<section class="new__cta">
 		<div class="card__list new__cta-container">
@@ -51,30 +73,8 @@
 		</div>
 	</section>
 
-	<section class="fdw__cta">
-		<div class="card__list fdw__cta-container">
-			<a href="/fokus-der-woche" class="fdw__cta-link">
-				{{- partial "svgs/fdw_svg.html" . -}}
-			</a>
-			{{ $fdwArtikel := where .Site.Pages ".Params.fdw" true }}
-			{{ range first 1 $fdwArtikel.ByDate.Reverse }}
-				<a href="{{.RelPermalink}}" class="card card--grey fdw__cta-card">
-					<div class="card__img-container">
-						<img srcset="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }},
-							{{ .Site.Params.cloudinary_url }}/f_auto,h_180,w_270,q_auto:good/{{ .Params.hero_img }} 1100w,
-							{{ .Site.Params.cloudinary_url }}/f_auto,h_167,w_250,q_auto:good/{{ .Params.hero_img }} 900w"
-							src="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }}"
-							alt="{{ .Params.img_description }}"
-							class="card__img"
-						/>
-					</div>
-					<div class="card__content">
-						<h3 class="card__content-title">{{ .Title }}</h3>
-						<div class="card__content-date">{{ .Date.Format .Site.Params.DateForm }}</div>
-					</div>
-				</a>
-			{{ end }}
-		</div>
+	<section class="map">
+			{{- partial "world_map.html" . -}}
 	</section>
 
 	<section class="ukraine">


### PR DESCRIPTION
As requested, the map and FdW sections on the homepage have been swapped, now making the FdW section the first section in order of precedence.

Additionally, the following article(s) have been uploaded to Chinderzytig.ch:
- Der Kampf um die Wahl **(FdW)**: 04.10.2023