### PR TITLE
Create Landscape article card

### DIFF
--- a/assets/sass/abstracts/_mixins.scss
+++ b/assets/sass/abstracts/_mixins.scss
@@ -3,6 +3,11 @@
 	padding: 3rem 0;
 }
 
+@mixin cta-type($bgc, $bs, $bc) {
+	background-color: $bgc;
+	border-#{$bs}: 2.5rem solid $bc;
+}
+
 @mixin newsletter-field($bg-color, $border-color) {
 	background-color: $bg-color;
 	border: 2px solid $border-color;

--- a/assets/sass/abstracts/_variables.scss
+++ b/assets/sass/abstracts/_variables.scss
@@ -39,6 +39,7 @@ $verdigris: #30AFAA;
 $celadon: #358280;
 $orange: #EC633F;
 $jonquil: #FFCF04;
+$engineering-orange: #CD0000;
 
 $black: #000;
 $white: #fff;

--- a/assets/sass/abstracts/_variables.scss
+++ b/assets/sass/abstracts/_variables.scss
@@ -34,6 +34,7 @@ $color-white: #fff;
 $seasalt: #FAFAFA;
 $cultured: #F4F4F4;
 $platinum: #E6E5E2;
+$silver: #A6A5A3;
 $davy-grey: #4C4C4C;
 $verdigris: #30AFAA;
 $celadon: #358280;

--- a/assets/sass/abstracts/_variables.scss
+++ b/assets/sass/abstracts/_variables.scss
@@ -48,8 +48,10 @@ $margin-s: 3rem;
 $margin-m: 6rem;
 
 /* ----- TYPOGRAPHY ------ */
-$font-patrick: 'Patrick Hand';
-$font-fallback: cursive;
+$font-patrick: 'Patrick Hand', cursive;
+$font-andika: 'Andika', sans-serif;
+$font-amatic: 'Amatic SC', cursive;
+$font-spartan: 'League Spartan', sans-serif;
 
 $font-small: 1.6rem;
 $font-default: 1.8rem;

--- a/assets/sass/base/_typography.scss
+++ b/assets/sass/base/_typography.scss
@@ -1,5 +1,5 @@
 body {
-	font-family: 'Andika', sans-serif;
+	font-family: $font-andika;
 	font-size: $font-default;
 	font-weight: 100;
 	line-height: 1.6;
@@ -16,7 +16,7 @@ body {
 
 /* ----- HEADINGS ------ */
 .heading {
-	font-family: $font-patrick, $font-fallback;
+	font-family: $font-patrick;
 	font-size: $font-heading;
 	text-transform: uppercase;
 	margin-bottom: $margin-s;

--- a/assets/sass/components/_arbeitsmaterial-shortcode.scss
+++ b/assets/sass/components/_arbeitsmaterial-shortcode.scss
@@ -9,7 +9,7 @@
 
 	&__heading {
 		font-size: $font-bigger;
-		font-family: $font-patrick, $font-fallback;
+		font-family: $font-patrick;
 		color: $chinder-orange;
 		margin-bottom: 1.5rem;
 	}

--- a/assets/sass/components/_btn.scss
+++ b/assets/sass/components/_btn.scss
@@ -1,5 +1,5 @@
 .btn {
-	font-family: $font-patrick, $font-fallback;
+	font-family: $font-patrick;
 	font-size: $font-big;
 	background-color: $color-white;
 	border: 2px solid $color-black;

--- a/assets/sass/components/_card.scss
+++ b/assets/sass/components/_card.scss
@@ -122,15 +122,18 @@
 
 	&__content {
 		width: 100%;
-		padding: 1.5rem;
+		padding: 2rem;
 		display: flex;
 		flex-direction: column;
-		justify-content: space-between;
+
+		&-pretitle {
+			font-family: $font-spartan;
+			color: $engineering-orange;
+		}
 
 		&-title {
-			font-family: $font-patrick;
-			font-size: $font-big;
-			font-weight: 700;
+			font-family: $font-amatic;
+			font-size: 3.5rem;
 
 			&--highlight {
 				font-family: $font-patrick;

--- a/assets/sass/components/_card.scss
+++ b/assets/sass/components/_card.scss
@@ -103,9 +103,19 @@
 .lard {
 	height: 30rem;
 	width: 100%;
-	margin-top: 3rem;
 	display: flex;
 	box-shadow: 0.8rem 0.8rem $silver;
+
+	@include respond(tab-port-sm) {
+		flex-direction: column;
+		height: 100rem;
+	}
+
+	@include respond(phone-land-lg) { height: 90rem; }
+
+	@include respond(phone-xl) { height: 80rem; }
+
+	@include respond(phone-lg) { height: 70rem; }
 
 	&:link,
 	&:visited {
@@ -129,19 +139,22 @@
 
 	&__img {
 		height: 30rem;
+
+		@include respond(tab-port-sm) {
+			height: auto;
+			width: 100%;
+		}
 	}
 
 	&__content {
 		width: 100%;
+		height: 100%;
 		padding: 2rem;
 		display: flex;
 		flex-direction: column;
 		justify-content: space-between;
 
-		&-grouping {
-		}
-
-		&-pretitle {
+		&-topic {
 			font-family: $font-spartan;
 			color: $engineering-orange;
 		}
@@ -150,11 +163,6 @@
 			font-family: $font-amatic;
 			font-size: 3.5rem;
 			margin: -1.2rem 0 1.5rem 0;
-
-			&--highlight {
-				font-family: $font-patrick;
-				font-size: $font-heading;
-			}
 		}
 	}
 }

--- a/assets/sass/components/_card.scss
+++ b/assets/sass/components/_card.scss
@@ -38,12 +38,12 @@
 		@include respond(tab-port-xl) { height: 21.3rem; }
 
 		&-title {
-			font-family: $font-patrick, $font-fallback;
+			font-family: $font-patrick;
 			font-size: $font-big;
 			font-weight: 700;
 
 			&--highlight {
-				font-family: $font-patrick, $font-fallback;
+				font-family: $font-patrick;
 				font-size: $font-heading;
 			}
 		}
@@ -128,12 +128,12 @@
 		justify-content: space-between;
 
 		&-title {
-			font-family: $font-patrick, $font-fallback;
+			font-family: $font-patrick;
 			font-size: $font-big;
 			font-weight: 700;
 
 			&--highlight {
-				font-family: $font-patrick, $font-fallback;
+				font-family: $font-patrick;
 				font-size: $font-heading;
 			}
 		}

--- a/assets/sass/components/_card.scss
+++ b/assets/sass/components/_card.scss
@@ -136,6 +136,10 @@
 		padding: 2rem;
 		display: flex;
 		flex-direction: column;
+		justify-content: space-between;
+
+		&-grouping {
+		}
 
 		&-pretitle {
 			font-family: $font-spartan;
@@ -145,6 +149,7 @@
 		&-title {
 			font-family: $font-amatic;
 			font-size: 3.5rem;
+			margin: -1.2rem 0 1.5rem 0;
 
 			&--highlight {
 				font-family: $font-patrick;

--- a/assets/sass/components/_card.scss
+++ b/assets/sass/components/_card.scss
@@ -99,3 +99,43 @@
 		}
 	}
 }
+
+.lard {
+	height: 30rem;
+	width: 100%;
+	margin-top: 3rem;
+	display: flex;
+
+	&:link,
+	&:visited {
+		text-decoration: none;
+		color: $color-black;
+	}
+
+	&--grey { background-color: $chinder-cultured; }
+
+	&--white { background-color: $color-white; }
+
+	&__img {
+		height: 30rem;
+	}
+
+	&__content {
+		width: 100%;
+		padding: 1.5rem;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+
+		&-title {
+			font-family: $font-patrick, $font-fallback;
+			font-size: $font-big;
+			font-weight: 700;
+
+			&--highlight {
+				font-family: $font-patrick, $font-fallback;
+				font-size: $font-heading;
+			}
+		}
+	}
+}

--- a/assets/sass/components/_card.scss
+++ b/assets/sass/components/_card.scss
@@ -105,11 +105,22 @@
 	width: 100%;
 	margin-top: 3rem;
 	display: flex;
+	box-shadow: 0.8rem 0.8rem $silver;
 
 	&:link,
 	&:visited {
 		text-decoration: none;
 		color: $color-black;
+	}
+
+	&:hover {
+		transform: translateY(-1rem);
+		box-shadow: 1.1rem 1.1rem $silver;;
+	}
+
+	&:active {
+		transform: translateY(1rem);
+		box-shadow: 0.5rem 0.5rem rgba(166, 165, 163, 0.65);
 	}
 
 	&--grey { background-color: $chinder-cultured; }

--- a/assets/sass/components/_cta.scss
+++ b/assets/sass/components/_cta.scss
@@ -1,0 +1,6 @@
+.cta {
+	padding: 4rem 3rem;
+
+	&--verL { @include cta-type($verdigris, left, $celadon); }
+	&--verR { @include cta-type($verdigris, right, $celadon); }
+}

--- a/assets/sass/components/_document.scss
+++ b/assets/sass/components/_document.scss
@@ -11,7 +11,7 @@
 		@include respond(tab-port-xl) { width: 25rem; }
 
 		&-title {
-			font-family: $font-patrick, $font-fallback;
+			font-family: $font-patrick;
 			text-align: center;
 			margin-bottom: 2rem;
 		}

--- a/assets/sass/components/_impfstoffe.scss
+++ b/assets/sass/components/_impfstoffe.scss
@@ -70,7 +70,7 @@
 	}
 
 	text {
-		font-family: $font-patrick, $font-fallback;
+		font-family: $font-patrick;
 		font-size: $font-bigger;
 
 		@include respond(phone-xl) { font-size: 3rem; }

--- a/assets/sass/components/_popup.scss
+++ b/assets/sass/components/_popup.scss
@@ -45,7 +45,7 @@
 	&__text { color: #ffffff; }
 
 	&__title {
-		font-family: $font-patrick, $font-fallback;
+		font-family: $font-patrick;
 		margin-top: -20px;
 	}
 

--- a/assets/sass/components/_profile.scss
+++ b/assets/sass/components/_profile.scss
@@ -32,7 +32,7 @@
 	}
 
 	&__name,
-	&__title { font-family: $font-patrick, $font-fallback; }
+	&__title { font-family: $font-patrick; }
 
 	&__name {
 		font-size: $font-big;

--- a/assets/sass/components/_world_map.scss
+++ b/assets/sass/components/_world_map.scss
@@ -34,6 +34,6 @@
 		display: none;
 		fill: $color-black;
 		font-size: 4rem;
-		font-family: $font-patrick, $font-fallback;
+		font-family: $font-patrick;
 	}
 }

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -10,6 +10,7 @@
 @import "components/btn";
 @import "components/card";
 @import "components/container_center";
+@import "components/cta";
 @import "components/definition";
 @import "components/document";
 @import "components/fdw_svg";

--- a/assets/sass/pages/_404.scss
+++ b/assets/sass/pages/_404.scss
@@ -4,7 +4,7 @@
 	align-items: center;
 
 	&__text {
-		font-family: $font-patrick, $font-fallback;
+		font-family: $font-patrick;
 
 		&--title {
 			font-weight: 700;

--- a/assets/sass/pages/_single.scss
+++ b/assets/sass/pages/_single.scss
@@ -56,7 +56,7 @@
 
 		h3 {
 			font-size: $font-bigger;
-			font-family: $font-patrick, $font-fallback;
+			font-family: $font-patrick;
 			color: $chinder-orange;
 			margin-bottom: 1.5rem;
 		}

--- a/assets/sass/pages/_single.scss
+++ b/assets/sass/pages/_single.scss
@@ -1,10 +1,6 @@
 .single {
 
-	&__container {
-		padding: 3rem;
-
-		@include respond(tab-land) { padding: 0; }
-	}
+	&__container { padding: 3rem; }
 
 	&__image {
 		display: flex;

--- a/assets/sass/pages/_unsere-geschichte.scss
+++ b/assets/sass/pages/_unsere-geschichte.scss
@@ -20,7 +20,7 @@
 	}
 
 	h3 {
-		font-family: $font-patrick, $font-fallback;
+		font-family: $font-patrick;
 		font-size: $font-bigger;
 		color: $chinder-orange;
 		margin-bottom: 2rem;

--- a/assets/sass/pages/_verein.scss
+++ b/assets/sass/pages/_verein.scss
@@ -7,7 +7,7 @@
 	}
 
 	&__history-quote {
-		font-family: $font-patrick, $font-fallback;
+		font-family: $font-patrick;
 		font-size: 5rem;
 		word-spacing: 1rem;
 		letter-spacing: .5rem;

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,30 +1,4 @@
 {{define "main"}}
-	<section class="fdw__cta">
-		<div class="card__list fdw__cta-container">
-			<a href="/fokus-der-woche" class="fdw__cta-link">
-				{{- partial "svgs/fdw_svg.html" . -}}
-			</a>
-			{{ $fdwArtikel := where .Site.Pages ".Params.fdw" true }}
-			{{ range first 1 $fdwArtikel.ByDate.Reverse }}
-				<a href="{{.RelPermalink}}" class="card card--grey fdw__cta-card">
-					<div class="card__img-container">
-						<img srcset="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }},
-							{{ .Site.Params.cloudinary_url }}/f_auto,h_180,w_270,q_auto:good/{{ .Params.hero_img }} 1100w,
-							{{ .Site.Params.cloudinary_url }}/f_auto,h_167,w_250,q_auto:good/{{ .Params.hero_img }} 900w"
-							src="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }}"
-							alt="{{ .Params.img_description }}"
-							class="card__img"
-						/>
-					</div>
-					<div class="card__content">
-						<h3 class="card__content-title">{{ .Title }}</h3>
-						<div class="card__content-date">{{ .Date.Format .Site.Params.DateForm }}</div>
-					</div>
-				</a>
-			{{ end }}
-		</div>
-	</section>
-
 	<div class="cta">
 		{{ $artikel := where (where .Site.Pages ".Params.artikel" true) ".Params.fdw" true }}
 		{{ range first 1 $artikel.ByDate.Reverse }}
@@ -38,6 +12,7 @@
 				<div class="lard__content">
 					<h4 class="lard__content-pretitle">Fokus der Woche</h4>
 					<h3 class="lard__content-title">{{ .Title }}</h3>
+					<p class="lard__content-summary">{{ .Summary | truncate 200 }}</p>
 					<div class="lard__content-date">{{ .Date.Format .Site.Params.DateForm }}</div>
 				</div>
 			</a>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,4 +1,29 @@
 {{define "main"}}
+	<section class="fdw__cta">
+		<div class="card__list fdw__cta-container">
+			<a href="/fokus-der-woche" class="fdw__cta-link">
+				{{- partial "svgs/fdw_svg.html" . -}}
+			</a>
+			{{ $fdwArtikel := where .Site.Pages ".Params.fdw" true }}
+			{{ range first 1 $fdwArtikel.ByDate.Reverse }}
+				<a href="{{.RelPermalink}}" class="card card--grey fdw__cta-card">
+					<div class="card__img-container">
+						<img srcset="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }},
+							{{ .Site.Params.cloudinary_url }}/f_auto,h_180,w_270,q_auto:good/{{ .Params.hero_img }} 1100w,
+							{{ .Site.Params.cloudinary_url }}/f_auto,h_167,w_250,q_auto:good/{{ .Params.hero_img }} 900w"
+							src="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }}"
+							alt="{{ .Params.img_description }}"
+							class="card__img"
+						/>
+					</div>
+					<div class="card__content">
+						<h3 class="card__content-title">{{ .Title }}</h3>
+						<div class="card__content-date">{{ .Date.Format .Site.Params.DateForm }}</div>
+					</div>
+				</a>
+			{{ end }}
+		</div>
+	</section>
 
 	<div class="cta cta--verL">
 		<h2 class="heading heading__tertiary">Neuste Artikel</h2>
@@ -69,32 +94,6 @@
 			<div class="btn__container">
 				<a href="/alle-artikel" class="btn btn--secondary">Alle Artikel</a>
 			</div>
-		</div>
-	</section>
-
-	<section class="fdw__cta">
-		<div class="card__list fdw__cta-container">
-			<a href="/fokus-der-woche" class="fdw__cta-link">
-				{{- partial "svgs/fdw_svg.html" . -}}
-			</a>
-			{{ $fdwArtikel := where .Site.Pages ".Params.fdw" true }}
-			{{ range first 1 $fdwArtikel.ByDate.Reverse }}
-				<a href="{{.RelPermalink}}" class="card card--grey fdw__cta-card">
-					<div class="card__img-container">
-						<img srcset="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }},
-							{{ .Site.Params.cloudinary_url }}/f_auto,h_180,w_270,q_auto:good/{{ .Params.hero_img }} 1100w,
-							{{ .Site.Params.cloudinary_url }}/f_auto,h_167,w_250,q_auto:good/{{ .Params.hero_img }} 900w"
-							src="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }}"
-							alt="{{ .Params.img_description }}"
-							class="card__img"
-						/>
-					</div>
-					<div class="card__content">
-						<h3 class="card__content-title">{{ .Title }}</h3>
-						<div class="card__content-date">{{ .Date.Format .Site.Params.DateForm }}</div>
-					</div>
-				</a>
-			{{ end }}
 		</div>
 	</section>
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,5 +1,29 @@
 {{define "main"}}
 
+	<div class="cta cta--verL">
+		<h2 class="heading heading__tertiary">Neuste Artikel</h2>
+		<div class="card__container">
+			{{ $artikel := where (where .Site.Pages ".Params.artikel" true) ".Params.fdw" false }}
+			{{ range first 1 $artikel.ByDate.Reverse }}
+				<a href="{{.RelPermalink}}" class="card card--white">
+					<div class="card__img-container">
+						<img srcset="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }},
+						{{ .Site.Params.cloudinary_url }}/f_auto,h_180,w_270,q_auto:good/{{ .Params.hero_img }} 1100w,
+						{{ .Site.Params.cloudinary_url }}/f_auto,h_167,w_250,q_auto:good/{{ .Params.hero_img }} 900w"
+						src="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }}"
+						alt="{{ .Params.img_description }}"
+						class="card__img"
+						/>
+					</div>
+					<div class="card__content">
+						<h3 class="card__content-title">{{ .Title }}</h3>
+						<div class="card__content-date">{{ .Date.Format .Site.Params.DateForm }}</div>
+					</div>
+				</a>
+			{{ end }}
+		</div>
+	</div>
+
 	<section class="new__cta">
 		<div class="card__list new__cta-container">
 			<h2 class="heading heading__tertiary">Neuste Artikel</h2>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -26,12 +26,12 @@
 	</section>
 
 	<div class="cta">
-		{{ $artikel := where (where .Site.Pages ".Params.artikel" true) ".Params.fdw" false }}
+		{{ $artikel := where (where .Site.Pages ".Params.artikel" true) ".Params.fdw" true }}
 		{{ range first 1 $artikel.ByDate.Reverse }}
 			<a href="{{.RelPermalink}}" class="lard lard--grey">
 				<div class="lard__img-container">
 					<img src="{{ .Site.Params.cloudinary_url }}/q_auto:good/graphics/placeholder_fdw_fychpb.png"
-					alt="{{ .Params.img_description }}"
+					alt="Cartoon-Bild eines Mädchens, das eine Lupe hochhält"
 					class="lard__img"
 					/>
 				</div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -36,6 +36,7 @@
 					/>
 				</div>
 				<div class="lard__content">
+					<h4 class="lard__content-pretitle">Fokus der Woche</h4>
 					<h3 class="lard__content-title">{{ .Title }}</h3>
 					<div class="lard__content-date">{{ .Date.Format .Site.Params.DateForm }}</div>
 				</div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -25,28 +25,22 @@
 		</div>
 	</section>
 
-	<div class="cta cta--verL">
-		<h2 class="heading heading__tertiary">Neuste Artikel</h2>
-		<div class="card__container">
-			{{ $artikel := where (where .Site.Pages ".Params.artikel" true) ".Params.fdw" false }}
-			{{ range first 1 $artikel.ByDate.Reverse }}
-				<a href="{{.RelPermalink}}" class="card card--white">
-					<div class="card__img-container">
-						<img srcset="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }},
-						{{ .Site.Params.cloudinary_url }}/f_auto,h_180,w_270,q_auto:good/{{ .Params.hero_img }} 1100w,
-						{{ .Site.Params.cloudinary_url }}/f_auto,h_167,w_250,q_auto:good/{{ .Params.hero_img }} 900w"
-						src="{{ .Site.Params.cloudinary_url }}/f_auto,h_200,w_300,q_auto:good/{{ .Params.hero_img }}"
-						alt="{{ .Params.img_description }}"
-						class="card__img"
-						/>
-					</div>
-					<div class="card__content">
-						<h3 class="card__content-title">{{ .Title }}</h3>
-						<div class="card__content-date">{{ .Date.Format .Site.Params.DateForm }}</div>
-					</div>
-				</a>
-			{{ end }}
-		</div>
+	<div class="cta">
+		{{ $artikel := where (where .Site.Pages ".Params.artikel" true) ".Params.fdw" false }}
+		{{ range first 1 $artikel.ByDate.Reverse }}
+			<a href="{{.RelPermalink}}" class="lard lard--grey">
+				<div class="lard__img-container">
+					<img src="{{ .Site.Params.cloudinary_url }}/q_auto:good/graphics/placeholder_fdw_fychpb.png"
+					alt="{{ .Params.img_description }}"
+					class="lard__img"
+					/>
+				</div>
+				<div class="lard__content">
+					<h3 class="lard__content-title">{{ .Title }}</h3>
+					<div class="lard__content-date">{{ .Date.Format .Site.Params.DateForm }}</div>
+				</div>
+			</a>
+		{{ end }}
 	</div>
 
 	<section class="new__cta">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -11,7 +11,7 @@
 				</div>
 				<div class="lard__content">
 					<div class="lard__content-grouping">
-						<h4 class="lard__content-pretitle">Fokus der Woche</h4>
+						<h4 class="lard__content-topic">Fokus der Woche</h4>
 						<h3 class="lard__content-title">{{ .Title }}</h3>
 						<p class="lard__content-summary">{{ .Summary | truncate 200 }}</p>
 					</div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -4,7 +4,7 @@
 		{{ range first 1 $artikel.ByDate.Reverse }}
 			<a href="{{.RelPermalink}}" class="lard lard--grey">
 				<div class="lard__img-container">
-					<img src="{{ .Site.Params.cloudinary_url }}/q_auto:good/graphics/placeholder_fdw_fychpb.png"
+					<img src="{{ .Site.Params.cloudinary_url }}/q_auto:good/graphics/fdw-hero_nkmrti.png"
 					alt="Cartoon-Bild eines Mädchens, das eine Lupe hochhält"
 					class="lard__img"
 					/>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -10,9 +10,11 @@
 					/>
 				</div>
 				<div class="lard__content">
-					<h4 class="lard__content-pretitle">Fokus der Woche</h4>
-					<h3 class="lard__content-title">{{ .Title }}</h3>
-					<p class="lard__content-summary">{{ .Summary | truncate 200 }}</p>
+					<div class="lard__content-grouping">
+						<h4 class="lard__content-pretitle">Fokus der Woche</h4>
+						<h3 class="lard__content-title">{{ .Title }}</h3>
+						<p class="lard__content-summary">{{ .Summary | truncate 200 }}</p>
+					</div>
 					<div class="lard__content-date">{{ .Date.Format .Site.Params.DateForm }}</div>
 				</div>
 			</a>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,4 @@
 {{define "main"}}
-	<section class="map">
-			{{- partial "world_map.html" . -}}
-	</section>
 
 	<section class="new__cta">
 		<div class="card__list new__cta-container">
@@ -75,6 +72,10 @@
 				</a>
 			{{ end }}
 		</div>
+	</section>
+
+	<section class="map">
+			{{- partial "world_map.html" . -}}
 	</section>
 
 	<section class="ukraine">


### PR DESCRIPTION
As part of the Chinderzytig redesign {v3) **updates:**
- created a landscape version of the article card to be used throughout the website
- created the styling basis (although not employed) for the new cta colouring scheme

<img width="1078" alt="CleanShot 2023-10-09 at 06 38 58@2x" src="https://github.com/Chinderzytig/chinderzytig-website/assets/16960228/62367eb1-e604-46e6-8a66-89897fde6ba2">

![CleanShot 2023-10-09 at 06 39 26](https://github.com/Chinderzytig/chinderzytig-website/assets/16960228/9b470dbb-3c33-4feb-bbad-fae6e3e9a9d7)

**fixes:**
- fixed padding issue on single article pages by removing the ```padding: 0``` media query that was being employed'