### PR TITLE
Add new pricing benefits section

### DIFF
--- a/assets/sass/components/_pricing-benefits.scss
+++ b/assets/sass/components/_pricing-benefits.scss
@@ -1,0 +1,4 @@
+.pricing-benefits {
+	background-color: $white;
+	margin-top: $margin-s;
+}

--- a/assets/sass/components/_pricing-benefits.scss
+++ b/assets/sass/components/_pricing-benefits.scss
@@ -1,4 +1,14 @@
 .pricing-benefits {
 	background-color: $white;
-	margin-top: $margin-s;
+	box-shadow: .8rem .8rem $celadon;
+	width: 75%;
+
+	margin: 3rem auto 0 auto;
+	border-collapse: collapse;
+
+	td, th {
+	  border: 1px solid $celadon;
+	  text-align: left;
+	  padding: 1rem;
+	}
 }

--- a/assets/sass/components/_pricing-benefits.scss
+++ b/assets/sass/components/_pricing-benefits.scss
@@ -1,10 +1,12 @@
 .pricing-benefits {
 	background-color: $white;
 	box-shadow: .8rem .8rem $celadon;
-	width: 75%;
+	width: 100%;
 
 	margin: 3rem auto 0 auto;
 	border-collapse: collapse;
+
+	td { width: 50%; }
 
 	td, th {
 	  border: 1px solid $celadon;

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -23,6 +23,7 @@
 @import "components/nr-webreader";
 @import "components/osano";
 @import "components/popup";
+@import "components/pricing-benefits";
 @import "components/pricing";
 @import "components/profile";
 @import "components/search";

--- a/data/partials/testimonial.yaml
+++ b/data/partials/testimonial.yaml
@@ -5,9 +5,9 @@ companies:
       img: "keystone_testimonial_wsmkr8.png"
       desc: "Keystone SDA logo"
   quote: |
-    "Das Konzept der Chinderzytig überzeugt uns. Medienkompetenz für Kinder und
+    Das Konzept der Chinderzytig überzeugt uns. Medienkompetenz für Kinder und
     Jugendliche ist elementar. Wir freuen uns deshalb sehr, dürfen wir das
-    Projekt mit unseren Inhalten unterstützen."
+    Projekt mit unseren Inhalten unterstützen.
   quotee: "Sandro Mühlebach, Head of Content Development"
   company: "Keystone SDA"
 - alias: "mirroco"
@@ -16,8 +16,8 @@ companies:
       img: "mirroco_testimonial_lv0o5f.png"
       desc: "Mirroco AG logo"
   quote: |
-    "Ich bin ein grosser Fan der Chinderzytig! Sie bringt die Welt auf fesselnde
+    Ich bin ein grosser Fan der Chinderzytig! Sie bringt die Welt auf fesselnde
     Weise zu den Kindern und weckt mit fundiertem Wissen die Neugier der Kinder
-    für komplexere Zusammenhänge. Danke für euer wunderbares Engagement. Ich empfehle euch mit Freude weiter!"
+    für komplexere Zusammenhänge. Danke für euer wunderbares Engagement. Ich empfehle euch mit Freude weiter!
   quotee: "Paula Duwan, Founderin"
   company: "Mirroco AG"

--- a/layouts/_default/angebote.html
+++ b/layouts/_default/angebote.html
@@ -14,4 +14,6 @@
 
 	{{ partial "visible-info.html" . }}
 
+	{{ partial "pricing-benefits.html" }}
+
 {{ end }}

--- a/layouts/partials/pricing-benefits.html
+++ b/layouts/partials/pricing-benefits.html
@@ -8,4 +8,32 @@
 		jährlich (Artikel und Arbeitsmaterialien). Ihr Beitrag unterstützt uns wie
 		folgt:
 	</p>
+	<table class="pricing-benefits">
+	  <tr>
+	    <th>Folgendes Angebote</th>
+	    <th>...finanziert folgende Leistunge</th>
+	  </tr>
+	  <tr>
+	    <td>Abonnement ohne Arbeitsmaterial à CHF 40.-</td>
+	    <td>2 von total 130 Artikeln</td>
+	  </tr>
+	  <tr>
+	    <td>Abonnement mit Arbeitsmaterial à CHF 60.-</td>
+	    <td>3 von total 208 Produkten</td>
+	  </tr>
+		<tr>
+	    <td>Visible Learning basic, à CHF 570.-</td>
+	    <td>
+				28 von 208 Chinderzytig-Produkten oder die Möglichkeit, uns an
+				spezifischen Bildungsmessen präsent in Szene setzen zu können
+	    </td>
+	  </tr>
+		<tr>
+	    <td>Visible Learning professional, à CHF 970.-</td>
+	    <td>
+				48 von 208 Produkten, was ca. 3 Monaten Chinderzytig entspricht oder ein
+				Halbjahreslohn der Administration
+	    </td>
+	  </tr>
+	</table>
 </div>

--- a/layouts/partials/pricing-benefits.html
+++ b/layouts/partials/pricing-benefits.html
@@ -1,0 +1,11 @@
+<div class="cta cta--verR">
+	<h2 class="deading deading__cta deading--white">
+		Nützen für den Verein Chinderzytig
+	</h2>
+	<p class="cta__chunk cta__chunk-btnless cta__chunk--white">
+		Durch ihre finanzielle Unterstützung können wir längerfristig planen und
+		ein sozialer Arbeitgeber sein. Wir veröffentlichen aktuell 208 Produkte
+		jährlich (Artikel und Arbeitsmaterialien). Ihr Beitrag unterstützt uns wie
+		folgt:
+	</p>
+</div>


### PR DESCRIPTION
As part of the ongoing updates to chinderzvtig.ch:
- Added a new pricing benefits section on ```Angebote.html```, similar to that on ```unterrichtsideen.html``` but only listing the relevant information for the related Abonnements:

<img width="1100" alt="CleanShot 2023-11-22 at 22 00 50@2x" src="https://github.com/Chinderzytig/chinderzytig-website/assets/16960228/e86cb51c-92ae-40c3-ba2a-0f1ad7ba5424">
