### PR TITLE
Create buffer advertisment card

### DIFF
--- a/assets/sass/components/_card.scss
+++ b/assets/sass/components/_card.scss
@@ -162,4 +162,19 @@
 	}
 
 	&__ghost { @extend .card__port; }
+
+	&__advertise {
+		@extend .card__port;
+		border: .3rem dashed $white;
+		color: $white;
+		font-size: 3rem;
+		font-weight: bold;
+		text-align: center;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+
+		&-text { width: 80%; }
+	}
+
 }

--- a/layouts/_default/unterrichtsideen.html
+++ b/layouts/_default/unterrichtsideen.html
@@ -16,6 +16,7 @@
 			"bgColor" "cultured"
 			"imgClass" "--pdf"
 			"ghost" "false"
+			"advertise" "false"
 		)
 	}}
 
@@ -32,6 +33,7 @@
 			"bgColor" "cultured"
 			"imgClass" "--pdf"
 			"ghost" "false"
+			"advertise" "true"
 		)
 	}}
 

--- a/layouts/partials/data-card.html
+++ b/layouts/partials/data-card.html
@@ -9,6 +9,7 @@
 {{ $bgColor := .bgColor }}
 {{ $imgClass := .imgClass }}
 {{ $ghost := .ghost }}
+{{ $advertise := .advertise }}
 
 <div class="cta cta--{{ $cta }}">
 	<h2 class="deading deading--{{ $headingColor }}">{{ $heading }}</h2>
@@ -38,6 +39,13 @@
 		{{ end }}
 		{{ if eq $ghost "true" }}
 			<div class="card__ghost"></div>
+		{{ end }}
+		{{ if eq $advertise "true" }}
+			<div class="card__advertise">
+				<div class="card__advertise-text">
+					Hier kann eure Zeitung sein... 
+				</div>
+			</div>
 		{{ end }}
 	</div>
 </div>


### PR DESCRIPTION
In order to make the "Beispiele aus dem Alltag" partial on the Unterrichtsideen page more symmetrical, I create a buffer like advertisement card:

![CleanShot 2023-12-17 at 15 18 17](https://github.com/Chinderzytig/chinderzytig-website/assets/16960228/0859f67e-3dab-4bd7-8885-3f8bd21cf89e)
