### PR TITLE
Add Twint button

### DIFF
--- a/assets/sass/components/_btn.scss
+++ b/assets/sass/components/_btn.scss
@@ -51,6 +51,7 @@
 			flex-wrap: wrap;
 			justify-content: space-between;
 			width: 100%;
+			margin-bottom: $margin-s;
 		}
 	}
 

--- a/layouts/_default/angebote.html
+++ b/layouts/_default/angebote.html
@@ -35,3 +35,9 @@
 	{{ partial "pricing-benefits.html" }}
 
 {{ end }}
+{{ define "scripts" }}
+	<script type="module">
+		import {TwintButton} from "https://unpkg.com/@raisenow/paylink-button@2/dist/TwintButton.js"
+		TwintButton.render('#rnw-paylink-button', {'solution-id': "dwfyc", 'solution-type': "donate", language: "de", size: "large", width: "full", 'color-scheme': "dark"})
+	</script>
+{{ end }}

--- a/layouts/partials/donation-cta.html
+++ b/layouts/partials/donation-cta.html
@@ -23,6 +23,7 @@
 			</button>
 			{{ end }}
 		</div>
+		<div id="rnw-paylink-button"></div>
 	</div>
 	</div>
 </div>


### PR DESCRIPTION
Added a Twint button to the Spenden CTA on ```angebote.html```, allowing donors an alternative way without using a credit card.

<img width="1104" alt="CleanShot 2024-03-20 at 14 06 18@2x" src="https://github.com/Chinderzytig/chinderzytig-website/assets/16960228/46ca002f-d55a-45b6-9d97-fc874cae3448">
