### PR TITLE
Flickity package links fix

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,12 +1,3 @@
-$(document).ready(function() {
-
-	$('#bread a[href^="/' + location.pathname.split("/")[1] + '"]').addClass('breadcrumb__active');
-
-	$("#js-scroll-to-comments").click(function() {
-		$('html, body').animate({scrollTop: $('.js-section-comments').offset().top}, 1000);
-	});
-});
-
 window.addEventListener("load",function() {
   setTimeout(function(){
 		window.scrollTo(0, 1);

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -26,9 +26,9 @@
 	{{ $options := (dict "outputStyle" "compressed") }}
 	{{ $style := resources.Get "sass/main.scss" | resources.ToCSS $options }}
 	<link rel="stylesheet" href="{{ $style.Permalink }}">
-	<link rel="stylesheet" href="https://unpkg.com/flickity@2/dist/flickity.min.css">
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flickity@2/dist/flickity.min.css">
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@algolia/algoliasearch-netlify-frontend@0/dist/algoliasearchNetlify.css" />
-	<script src="https://unpkg.com/flickity@2/dist/flickity.pkgd.min.js"></script>
+	<script src="https://cdn.jsdelivr.net/npm/flickity@2/dist/flickity.pkgd.min.js"></script>
 	<script src="https://cmp.osano.com/Azyw8hSD8hNpA1Jgf/d6cac08e-e7f0-4dc7-93a1-b0cf300a5019/osano.js"></script>
 	<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@algolia/algoliasearch-netlify-frontend@0/dist/algoliasearchNetlify.js"></script>
 	<script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>


### PR DESCRIPTION
Updated unpkg links for flickity by using jsdeliver. fixes issue below:

<img width="577" alt="CleanShot 2024-04-12 at 10 49 34@2x" src="https://github.com/Chinderzytig/chinderzytig-website/assets/16960228/f389fef4-babc-47a4-b245-2eae7e5f4b37">
